### PR TITLE
Expose monetio.readers in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test = [
 
 
 [tool.setuptools]
-packages = ["monetio", "monetio.models", "monetio.obs", "monetio.profile", "monetio.sat"]
+packages = ["monetio", "monetio.models", "monetio.obs", "monetio.profile", "monetio.readers", "monetio.sat"]
 package-data = {"monetio" = ["data/*.csv", "data/*.tsv", "data/*.txt", "data/*.png"]}
 
 


### PR DESCRIPTION
This change adds `monetio.readers` to the list of packages in `pyproject.toml`. This ensures that when `monetio` is installed (e.g., via `pip install .`), the readers sub-package is included and can be imported by users.

I verified this by:
1. Creating a clean virtual environment using `uv venv`.
2. Installing the package with `uv pip install .`.
3. Running `python -c "import monetio.readers"` and confirming it succeeds.
4. Running the test suite (`pytest`) to ensure no regressions were introduced. Note that existing test failures related to external API access (OpenAQ, AERONET) were confirmed to be present before the change.

---
*PR created automatically by Jules for task [11632840712934414021](https://jules.google.com/task/11632840712934414021) started by @bbakernoaa*