### PR TITLE
Fix: Ensure point data has fixed location coordinates unless specified

### DIFF
--- a/monetio/readers/base.py
+++ b/monetio/readers/base.py
@@ -79,6 +79,8 @@ class PointReader(BaseReader):
     Base class for point/tabular data (Observations) that utilizes PandasDriver.
     """
 
+    fixed_location = True
+
     def __init__(self):
         self.driver = PandasDriver()
 
@@ -218,7 +220,7 @@ class PointReader(BaseReader):
         if expand2d:
             # We pass kwargs to allow control over pivoting (wide_fmt or pivot)
             pivot = kwargs.get("wide_fmt", kwargs.get("pivot", True))
-            ds = ds_to_2d(ds, pivot=pivot)
+            ds = ds_to_2d(ds, pivot=pivot, fixed_location=self.fixed_location)
 
         # Add UGRID metadata
         if "node" in ds.dims:

--- a/monetio/readers/hytraj.py
+++ b/monetio/readers/hytraj.py
@@ -11,6 +11,8 @@ from .drivers import FileUtility
 
 @register_reader("hytraj")
 class HYTRAJReader(PointReader):
+    fixed_location = False
+
     def open_dataset(self, files, taglist=None, renumber=False, verbose=False, **kwargs):
         """
         Reads HYTRAJ tdump files.

--- a/monetio/readers/icartt.py
+++ b/monetio/readers/icartt.py
@@ -122,6 +122,8 @@ def read_icartt(filename: str, **kwargs) -> pd.DataFrame:
 class ICARTTReader(PointReader):
     """ICARTT Data Reader."""
 
+    fixed_location = False
+
     def open_dataset(
         self,
         files: str | list[str],

--- a/monetio/readers/ish.py
+++ b/monetio/readers/ish.py
@@ -450,7 +450,7 @@ class ISHReader(PointReader):
                 from ..util import ds_to_2d
 
                 pivot = kwargs.get("wide_fmt", kwargs.get("pivot", True))
-                ds = ds_to_2d(ds, pivot=pivot)
+                ds = ds_to_2d(ds, pivot=pivot, fixed_location=self.fixed_location)
 
                 # Identify metadata variables to preserve
                 metadata = xr.Dataset()
@@ -483,7 +483,7 @@ class ISHReader(PointReader):
                     from ..util import ds_to_2d
 
                     pivot = kwargs.get("wide_fmt", kwargs.get("pivot", True))
-                    ds = ds_to_2d(ds, pivot=pivot)
+                    ds = ds_to_2d(ds, pivot=pivot, fixed_location=self.fixed_location)
                     if (
                         "siteid" not in ds.coords
                         and "siteid" not in ds.data_vars

--- a/monetio/readers/pardump.py
+++ b/monetio/readers/pardump.py
@@ -11,6 +11,8 @@ from .drivers import FileUtility
 
 @register_reader("pardump")
 class PardumpReader(PointReader):
+    fixed_location = False
+
     def open_dataset(self, files, drange=None, century=2000, verbose=False, **kwargs):
         """
         Reads HYSPLIT PARDUMP binary files.

--- a/monetio/util.py
+++ b/monetio/util.py
@@ -556,7 +556,7 @@ def force_object_strings(df):
         return df
 
 
-def ds_to_2d(ds, pivot=True):
+def ds_to_2d(ds, pivot=True, fixed_location=False):
     """
     Lazily transform a 1D UGRID dataset into a 2D (time, node) dataset.
     If 'variable' is present in coordinates and pivot=True, it also pivots the data variables.
@@ -567,6 +567,8 @@ def ds_to_2d(ds, pivot=True):
         Input 1D dataset with 'time' and 'siteid' coordinates.
     pivot : bool, optional
         Whether to pivot by 'variable' column if present, by default True.
+    fixed_location : bool, optional
+        Whether to enforce fixed latitude/longitude/elevation per node, by default False.
 
     Returns
     -------
@@ -645,6 +647,18 @@ def ds_to_2d(ds, pivot=True):
         # but we rename it to 'node' for UGRID compliance.
         if "siteid" in ds2d.dims:
             ds2d = ds2d.rename({"siteid": "node"})
+
+        if fixed_location:
+            # Enforce fixed locations by averaging over time (ignoring NaNs)
+            # This fixes issues where missing time steps result in NaN lat/lon
+            for coord in ["latitude", "longitude", "elevation"]:
+                if coord in ds2d.coords:
+                    if "time" in ds2d[coord].dims and "node" in ds2d[coord].dims:
+                        try:
+                            # Use mean to reduce time dimension, ignoring NaNs
+                            ds2d.coords[coord] = ds2d[coord].mean(dim="time", skipna=True)
+                        except Exception:
+                            pass
 
         if "history" in ds2d.attrs:
             ds2d.attrs["history"] = f"{ds2d.attrs['history']}\n{history}"


### PR DESCRIPTION
This PR addresses the issue where latitude and longitude coordinates for fixed stations (like AERONET) were varying with time and containing NaNs when data was missing for some time steps.

Changes:
- Added `fixed_location` attribute to `PointReader` (default True).
- Updated `ds_to_2d` to reduce spatial coordinates to `(node,)` if `fixed_location` is True, by averaging over time (ignoring NaNs).
- Explicitly set `fixed_location = False` for readers that handle moving platforms: `ICARTTReader`, `HYTRAJReader`, and `PardumpReader`.
- Updated `ISHReader` usage of `ds_to_2d`.

Verified with a reproduction script and existing tests.

---
*PR created automatically by Jules for task [12659670653112606853](https://jules.google.com/task/12659670653112606853) started by @bbakernoaa*