### PR TITLE
Modernize WRF-Chem and add GRIB2 reader following Aero Protocol

### DIFF
--- a/monetio/__init__.py
+++ b/monetio/__init__.py
@@ -99,6 +99,8 @@ _READER_MODULES = {
     "prepchem": ".readers.prepchem",
     "raqms": ".readers.raqms",
     "ufs": ".readers.ufs",
+    "wrfchem": ".readers.wrfchem",
+    "grib2": ".readers.grib2",
     # Obs
     "airnow": ".readers.airnow",
     "aeronet": ".readers.aeronet",
@@ -140,7 +142,7 @@ def load(source: str, files=None, **kwargs):
         df = monetio.load("airnow", files=["2023-01-01", "2023-01-02"])
 
     Available sources:
-        Models: cmaq, camx, fv3chem, hysplit, hytraj, icap_mme, ncep_grib, pardump, prepchem, raqms, ufs
+        Models: cmaq, camx, fv3chem, hysplit, hytraj, icap_mme, ncep_grib, pardump, prepchem, raqms, ufs, wrfchem, grib2
         Obs: airnow, aeronet, aqs, cems, crn, improve, ish, ish_lite, nadp, openaq, pams
         Profile: icartt, tolnet, geoms, gml_ozonesonde
         Sat: goes, nesdis_edr_viirs, nesdis_eps_viirs, modis_ornl, nasa_modis, nesdis_frp

--- a/monetio/readers/aeronet.py
+++ b/monetio/readers/aeronet.py
@@ -239,12 +239,12 @@ class AERONETReader(PointReader):
 
         # Consistent with legacy: drop exact duplicates
         if hasattr(df, "drop_duplicates"):
-             df = df.drop_duplicates()
-        elif hasattr(df, "head"): # dask?
-             # For dask, drop_duplicates is expensive, but for consistency we might want it.
-             # In monetio legacy it only used joblib/serial so it was eager.
-             # We'll do it eager-style for now.
-             pass
+            df = df.drop_duplicates()
+        elif hasattr(df, "head"):  # dask?
+            # For dask, drop_duplicates is expensive, but for consistency we might want it.
+            # In monetio legacy it only used joblib/serial so it was eager.
+            # We'll do it eager-style for now.
+            pass
 
         # Force string columns to object for Pandas 3.0 compatibility
         df = force_object_strings(df)
@@ -870,7 +870,7 @@ class AERONET:
             self.url,
             inv_type=self.inv_type,
             interp_to_aod_values=self.new_aod_values,
-            n_procs=1, # Legacy always serial for single URL
+            n_procs=1,  # Legacy always serial for single URL
         )
         if self.df.empty:
             # Matches old behavior for some tests
@@ -902,6 +902,7 @@ class AERONET:
         self.siteid = siteid
         if dates is None:  # get the current day
             from datetime import datetime
+
             now = datetime.utcnow()
             self.dates = pd.date_range(start=now.date(), end=now, freq="H")
         else:
@@ -922,7 +923,7 @@ class AERONET:
             self.read_aeronet()
         except Exception as e:
             if "valid query but no data found" in str(e):
-                 raise
+                raise
             raise Exception(
                 f"loading from URL {self.url!r} failed. "
                 "If using `siteid`, check that the site is valid."
@@ -1001,6 +1002,7 @@ class AERONET:
     def _lines_from_url(self, *, n=10):
         """Read n lines from URL (legacy diagnostic)."""
         from itertools import islice
+
         if isinstance(self.url, str) and self.url.startswith("http"):
             import requests
 

--- a/monetio/readers/base.py
+++ b/monetio/readers/base.py
@@ -211,7 +211,9 @@ class PointReader(BaseReader):
                 ds = ds.rename({"index": "node"})
 
         # Set standard coordinates
-        coords = [c for c in ["time", "siteid", "latitude", "longitude", "elevation"] if c in ds.data_vars]
+        coords = [
+            c for c in ["time", "siteid", "latitude", "longitude", "elevation"] if c in ds.data_vars
+        ]
         ds = ds.set_coords(coords)
 
         # Ensure node coordinate is a simple integer range for both

--- a/monetio/readers/grib2.py
+++ b/monetio/readers/grib2.py
@@ -1,0 +1,113 @@
+"""Generalized GRIB2 Reader using grib2io"""
+
+import datetime
+from typing import List, Optional, Union
+
+import xarray as xr
+
+from .base import GriddedReader, register_reader
+
+
+@register_reader("grib2")
+class Grib2Reader(GriddedReader):
+    """
+    Generalized Reader for GRIB2 files using the grib2io engine.
+    """
+
+    def open_dataset(
+        self,
+        files: Union[str, List[str]],
+        engine: str = "grib2io",
+        filters: Optional[dict] = None,
+        **kwargs,
+    ) -> xr.Dataset:
+        """
+        Reads GRIB2 files using xarray and grib2io.
+
+        Parameters
+        ----------
+        files : Union[str, List[str]]
+            File path, list of paths, or glob pattern.
+        engine : str, optional
+            The xarray engine to use, by default "grib2io".
+        filters : dict, optional
+            Filters to pass to the engine (if supported), by default None.
+        **kwargs : dict
+            Additional arguments passed to xarray.open_mfdataset or the driver.
+
+        Returns
+        -------
+        xr.Dataset
+            The processed GRIB2 dataset.
+        """
+        if "engine" not in kwargs:
+            kwargs["engine"] = engine
+
+        if filters is not None and "backend_kwargs" not in kwargs:
+            kwargs["backend_kwargs"] = {"filters": filters}
+
+        # Use the driver to open files
+        # XarrayDriver handles S3, multiple files, etc.
+        ds = self.driver.open(files, **kwargs)
+
+        # Standardize and Harmonize
+        ds = self.harmonize(ds)
+
+        # Update history
+        history = f"{datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S')}: Read GRIB2 data using {engine}."
+        if "history" in ds.attrs:
+            ds.attrs["history"] = f"{ds.attrs['history']}\n{history}"
+        else:
+            ds.attrs["history"] = history
+
+        return ds
+
+    def harmonize(self, ds: xr.Dataset) -> xr.Dataset:
+        """
+        Harmonize GRIB2 metadata to Aero Protocol standards.
+
+        Parameters
+        ----------
+        ds : xr.Dataset
+            Input GRIB2 dataset.
+
+        Returns
+        -------
+        xr.Dataset
+            Harmonized dataset.
+        """
+        # 1. Coordinate Renaming (common in GRIB2)
+        rename_dict = {
+            "latitude": "latitude",
+            "longitude": "longitude",
+            "lat": "latitude",
+            "lon": "longitude",
+            "lat_0": "latitude",
+            "lon_0": "longitude",
+            "time": "time",
+            "valid_time": "time",
+            "step": "step",
+        }
+
+        actual_rename = {}
+        for k, v in rename_dict.items():
+            if k in ds.variables or k in ds.dims:
+                if v in ds.dims and k != v:
+                    continue
+                actual_rename[k] = v
+
+        if actual_rename:
+            ds = ds.rename(actual_rename)
+
+        # 2. Ensure latitude/longitude are coordinates
+        coord_vars = [v for v in ["latitude", "longitude", "time"] if v in ds.variables]
+        if coord_vars:
+            ds = ds.set_coords(coord_vars)
+
+        # 3. Scientific Hygiene: Strip whitespace from string attributes
+        for var in ds.variables:
+            for attr, val in ds[var].attrs.items():
+                if isinstance(val, str):
+                    ds[var].attrs[attr] = val.strip()
+
+        return ds

--- a/monetio/readers/wrfchem.py
+++ b/monetio/readers/wrfchem.py
@@ -2,8 +2,10 @@
 
 import datetime
 from functools import partial
-from typing import List, Union
+from typing import List, Optional, Union
 
+import numpy as np
+import pandas as pd
 import xarray as xr
 
 from .base import GriddedReader, register_reader
@@ -20,7 +22,7 @@ class WRFChemReader(GriddedReader):
         files: Union[str, List[str]],
         convert_to_ppb: bool = True,
         mech: str = "racm_esrl_vcp",
-        var_list: List[str] = None,
+        var_list: Optional[List[str]] = None,
         surf_only: bool = False,
         surf_only_nc: bool = False,
         **kwargs,
@@ -84,12 +86,32 @@ def wrfchem_preprocess(
     *,
     convert_to_ppb: bool = True,
     mech: str = "racm_esrl_vcp",
-    var_list: List[str] = None,
+    var_list: Optional[List[str]] = None,
     surf_only: bool = False,
     surf_only_nc: bool = False,
 ) -> xr.Dataset:
     """
-    Preprocess function for a single WRF-Chem file.
+    Preprocess function for a single WRF-Chem file following Aero Protocol.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input WRF-Chem dataset.
+    convert_to_ppb : bool, optional
+        Whether to convert gas species to ppbV, by default True.
+    mech : str, optional
+        Mechanism for diagnostics, by default "racm_esrl_vcp".
+    var_list : List[str], optional
+        List of variables to keep, by default None.
+    surf_only : bool, optional
+        Keep only surface layer, by default False.
+    surf_only_nc : bool, optional
+        Whether input is already surface-only, by default False.
+
+    Returns
+    -------
+    xr.Dataset
+        The preprocessed dataset.
     """
     # 1. Coordinate and Dimension Renaming
     rename_dict = {
@@ -99,48 +121,44 @@ def wrfchem_preprocess(
         "XLONG": "longitude",
         "XLAT": "latitude",
         "bottom_top": "z",
+        "bottom_top_stag": "z_stag",
+        "soil_layers_stag": "z_soil",
     }
-    # Check what exists
-    rename_dict = {k: v for k, v in rename_dict.items() if k in ds.variables or k in ds.dims}
-    ds = ds.rename(rename_dict)
+    # Only rename what exists
+    # We must be careful not to rename if target name already exists as a dimension
+    actual_rename = {}
+    for k, v in rename_dict.items():
+        if k in ds.variables or k in ds.dims:
+            if v in ds.dims and k != v:
+                # Target exists, maybe it's already renamed or there's a conflict
+                continue
+            actual_rename[k] = v
 
-    # 2. Subset variables if requested
+    if actual_rename:
+        ds = ds.rename(actual_rename)
+
+    # 2. Lazy Time Parsing
+    if "Times" in ds.variables:
+        ds = _parse_wrf_times(ds)
+
+    # 3. Subset variables if requested
     if var_list is not None:
         # We must keep coordinates and some essentials
-        essentials = ["latitude", "longitude", "time", "z"]
+        essentials = ["latitude", "longitude", "time", "z", "z_stag", "z_soil"]
         to_keep = set(var_list) | set(essentials)
         available = [v for v in ds.variables if v in to_keep]
         ds = ds[available]
 
-    # 3. Handle Surface Only
+    # 4. Handle Surface Only
     if surf_only and not surf_only_nc and "z" in ds.dims:
-        ds = ds.isel(z=0).expand_dims("z", axis=1)
+        ds = ds.isel(z=[0])
 
-    # 4. Unit Conversions
+    # 5. Unit Conversions (Lazy)
     if convert_to_ppb:
-        for i in ds.data_vars:
-            if "units" in ds[i].attrs and "ppmv" in ds[i].attrs["units"].lower():
-                ds[i] = ds[i] * 1000.0
-                ds[i].attrs["units"] = "ppbV"
+        ds = _convert_to_ppb(ds)
 
-    # convert "ug/kg-dryair -> ug/m3"
-    # Note: requires pressure and temperature which might not be in var_list
-    if "P" in ds.variables and "T" in ds.variables:
-        # This is very WRF specific and might need more careful implementation
-        # For now, following legacy logic if they exist
-        pass
-
-    # 5. Mapping tables
-    to_airnow = {
-        "OZONE": "o3",
-        "PM2.5": "PM2_5_DRY",
-        "PM10": "PM10",
-        "CO": "co",
-        "SO2": "so2",
-        "NO": "no",
-        "NO2": "no2",
-    }
-    ds.attrs["mapping_tables"] = {"airnow": to_airnow}
+    # convert "ug/kg-dryair -> ug/m3" if density can be calculated
+    ds = _convert_ugkg_to_ugm3(ds)
 
     # 6. Scientific Hygiene
     ds = ds.reset_coords()
@@ -161,5 +179,111 @@ def wrfchem_preprocess(
         ds.attrs["history"] = f"{ds.attrs['history']}\n{history}"
     else:
         ds.attrs["history"] = history
+
+    return ds
+
+
+def _parse_wrf_times(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Parse WRF 'Times' character array into a 'time' coordinate lazily.
+    """
+    times_var = ds.Times
+
+    # WRF Times is usually (time, DateStrLen)
+    # But it might be (Time, DateStrLen) if not renamed yet,
+    # but we just renamed Time -> time.
+
+    # Find the string dimension
+    string_dim = [d for d in times_var.dims if d != "time"]
+    if not string_dim:
+        if times_var.ndim == 1:
+            string_dim = [times_var.dims[0]]
+        else:
+            return ds
+
+    string_dim = string_dim[-1]
+
+    def _parse_times_wrapped(times_arr):
+        # times_arr is the core dimension part (DateStrLen)
+        # We use a vectorized version to be safe
+        def _single_parse(t):
+            try:
+                # Handle bytes or strings
+                if hasattr(t, "tobytes"):
+                    s = t.tobytes().decode().strip().replace("_", " ")
+                else:
+                    s = (
+                        "".join([c.decode() if hasattr(c, "decode") else c for c in t])
+                        .strip()
+                        .replace("_", " ")
+                    )
+                return np.datetime64(pd.to_datetime(s))
+            except Exception:
+                return np.datetime64("NaT")
+
+        # If it's more than 1D (because of vectorize=True), np.apply_along_axis is called by apply_ufunc
+        return _single_parse(times_arr)
+
+    # To avoid the xarray broadcasting issue, let's try to ensure times_var is a DataArray with correct dims
+    parsed_times = xr.apply_ufunc(
+        _parse_times_wrapped,
+        times_var,
+        input_core_dims=[[string_dim]],
+        output_core_dims=[[]],
+        vectorize=True,
+        dask="parallelized",
+        output_dtypes=[np.dtype("datetime64[ns]")],
+    )
+
+    # Force the name and dims of parsed_times to be 'time' if it was batch-dimensioned by it
+    if "time" in parsed_times.dims:
+        parsed_times = parsed_times.rename("time")
+
+    # If 'time' dimension already exists, update it
+    if "time" in ds.dims:
+        # Avoid assign_coords if it causes issues, just set it
+        ds.coords["time"] = parsed_times
+    else:
+        ds["time"] = parsed_times
+
+    return ds
+
+
+def _convert_to_ppb(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Lazy conversion of ppmv to ppbV.
+    """
+    for i in ds.data_vars:
+        if "units" in ds[i].attrs:
+            units = ds[i].attrs["units"].lower()
+            if "ppmv" in units:
+                ds[i] = ds[i] * 1000.0
+                ds[i].attrs["units"] = "ppbV"
+    return ds
+
+
+def _convert_ugkg_to_ugm3(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Lazy conversion of ug/kg-dryair to ug/m3.
+    """
+    if "ALT" in ds.variables:
+        for i in ds.data_vars:
+            if "units" in ds[i].attrs:
+                units = ds[i].attrs["units"].lower()
+                if "ug/kg" in units:
+                    ds[i] = ds[i] / ds["ALT"]
+                    ds[i].attrs["units"] = r"$\mu g m^{-3}$"
+    elif "P" in ds.variables and "PB" in ds.variables and "T" in ds.variables:
+        R = 287.05
+        P_tot = ds["P"] + ds["PB"]
+        T_actual = (ds["T"] + 300.0) * (P_tot / 100000.0) ** (287.05 / 1004.5)
+        rho = P_tot / (R * T_actual)
+
+        for i in ds.data_vars:
+            if "units" in ds[i].attrs:
+                units = ds[i].attrs["units"].lower()
+                if "ug/kg" in units:
+                    ds[i] = ds[i] * rho
+                    ds[i].attrs["units"] = r"$\mu g m^{-3}$"
 
     return ds

--- a/tests/test_aero_grib2.py
+++ b/tests/test_aero_grib2.py
@@ -1,0 +1,42 @@
+import numpy as np
+import xarray as xr
+
+from monetio.readers.grib2 import Grib2Reader
+
+
+def test_grib2_reader_open():
+    ds = xr.Dataset(
+        {"tmp": (("lat_0", "lon_0"), np.random.rand(10, 20))},
+        coords={"lat_0": np.arange(10), "lon_0": np.arange(20)},
+    )
+
+    reader = Grib2Reader()
+
+    import unittest.mock as mock
+
+    with mock.patch("monetio.readers.drivers.XarrayDriver.open", return_value=ds):
+        res = reader.open_dataset("dummy.grib2")
+
+    assert "latitude" in res.coords
+    assert "longitude" in res.coords
+    assert "history" in res.attrs
+    assert "grib2io" in res.attrs["history"]
+
+
+def test_grib2_reader_harmonize():
+    ds = xr.Dataset(
+        {"tmp": (("lat", "lon"), np.random.rand(10, 20))},
+        coords={
+            "lat": np.arange(10),
+            "lon": np.arange(20),
+            "valid_time": [np.datetime64("2023-01-01")],
+        },
+    )
+
+    reader = Grib2Reader()
+    res = reader.harmonize(ds)
+
+    assert "latitude" in res.coords
+    assert "longitude" in res.coords
+    # valid_time should be renamed to time
+    assert "time" in res.variables

--- a/tests/test_aero_load.py
+++ b/tests/test_aero_load.py
@@ -1,0 +1,45 @@
+import numpy as np
+import xarray as xr
+
+import monetio
+from monetio.readers.wrfchem import wrfchem_preprocess
+
+
+def test_load_wrfchem():
+    nx, ny, nz, nt = 4, 5, 3, 2
+    ds = xr.Dataset(
+        {
+            "OZONE": (("time", "z", "y", "x"), np.random.rand(nt, nz, ny, nx).astype(np.float32)),
+            "Times": (
+                ("time", "DateStrLen"),
+                np.array([list("2023-01-01_00:00:00"), list("2023-01-01_01:00:00")], dtype="|S1"),
+            ),
+        },
+        coords={"time": np.arange(nt), "y": np.arange(ny), "x": np.arange(nx), "z": np.arange(nz)},
+    )
+
+    import unittest.mock as mock
+
+    # Open dataset calls driver.open. Driver.open calls preprocess.
+    # So we should mock driver.open to return the preprocessed ds if we want to check results.
+    ds_pre = wrfchem_preprocess(ds)
+    with mock.patch("monetio.readers.drivers.XarrayDriver.open", return_value=ds_pre):
+        res = monetio.load("wrfchem", files="dummy.nc")
+
+    assert res.time.dtype == "datetime64[ns]"
+
+
+def test_load_grib2():
+    ds = xr.Dataset(
+        {"tmp": (("lat_0", "lon_0"), np.random.rand(10, 20))},
+        coords={"lat_0": np.arange(10), "lon_0": np.arange(20)},
+    )
+
+    import unittest.mock as mock
+
+    # Grib2Reader.open_dataset calls self.driver.open then harmonize.
+    # driver.open returns ds. harmonize returns harmonized ds.
+    with mock.patch("monetio.readers.drivers.XarrayDriver.open", return_value=ds):
+        res = monetio.load("grib2", files="dummy.grib2")
+
+    assert "latitude" in res.coords

--- a/tests/test_aero_wrfchem.py
+++ b/tests/test_aero_wrfchem.py
@@ -1,0 +1,85 @@
+import numpy as np
+import xarray as xr
+
+from monetio.readers.wrfchem import WRFChemReader, wrfchem_preprocess
+
+
+def make_mock_wrfchem_ds():
+    """Create a mock WRF-Chem dataset."""
+    nx, ny, nz, nt = 4, 5, 3, 2
+    ds = xr.Dataset(
+        {
+            "OZONE": (("time", "z", "y", "x"), np.random.rand(nt, nz, ny, nx).astype(np.float32)),
+            "PM2_5_DRY": (
+                ("time", "z", "y", "x"),
+                np.random.rand(nt, nz, ny, nx).astype(np.float32),
+            ),
+            "ALT": (("time", "z", "y", "x"), np.ones((nt, nz, ny, nx), dtype=np.float32) * 0.8),
+            "XLAT": (
+                ("time", "y", "x"),
+                np.broadcast_to(np.arange(ny)[:, None], (nt, ny, nx)).astype(np.float32),
+            ),
+            "XLONG": (
+                ("time", "y", "x"),
+                np.broadcast_to(np.arange(nx)[None, :], (nt, ny, nx)).astype(np.float32),
+            ),
+            "Times": (
+                ("time", "DateStrLen"),
+                np.array([list("2023-01-01_00:00:00"), list("2023-01-01_01:00:00")], dtype="|S1"),
+            ),
+        },
+        coords={
+            "time": np.arange(nt),
+            "y": np.arange(ny),
+            "x": np.arange(nx),
+            "z": np.arange(nz),
+        },
+    )
+    ds.OZONE.attrs["units"] = "ppmv"
+    ds.PM2_5_DRY.attrs["units"] = "ug/kg-dryair"
+    return ds
+
+
+def test_wrfchem_preprocess_eager():
+    ds = make_mock_wrfchem_ds()
+    res = wrfchem_preprocess(ds)
+
+    assert "time" in res.coords
+    assert res.time.dtype == "datetime64[ns]"
+    assert res.OZONE.attrs["units"] == "ppbV"
+    assert res.PM2_5_DRY.attrs["units"] == r"$\mu g m^{-3}$"
+    assert "latitude" in res.coords
+    assert "longitude" in res.coords
+    # Check unit conversion value: 0.8 ALT -> rho = 1.25. pm * 1.25.
+    np.testing.assert_allclose(res.PM2_5_DRY.values, ds.PM2_5_DRY.values / 0.8)
+
+
+def test_wrfchem_preprocess_lazy():
+    ds = make_mock_wrfchem_ds().chunk({"time": 1, "z": 1})
+    res = wrfchem_preprocess(ds)
+
+    assert res.OZONE.chunks is not None
+    assert "time" in res.coords
+    assert res.OZONE.attrs["units"] == "ppbV"
+
+    res_computed = res.compute()
+    assert res_computed.time.dtype == "datetime64[ns]"
+    np.testing.assert_allclose(res_computed.PM2_5_DRY.values, ds.PM2_5_DRY.values / 0.8, rtol=1e-5)
+
+
+def test_wrfchem_reader_open_dataset():
+    ds = make_mock_wrfchem_ds()
+    reader = WRFChemReader()
+
+    import unittest.mock as mock
+
+    # We want to test that open_dataset calls driver.open and harmonize.
+    # Since driver.open is expected to return the PREPROCESSED dataset,
+    # we should mock it to return a preprocessed dataset if we want to check harmonize.
+    ds_pre = wrfchem_preprocess(ds)
+    with mock.patch("monetio.readers.drivers.XarrayDriver.open", return_value=ds_pre):
+        res = reader.open_dataset("dummy.nc")
+
+    assert "history" in res.attrs
+    assert "Read WRF-Chem data" in res.attrs["history"]
+    assert res.time.dtype == "datetime64[ns]"


### PR DESCRIPTION
This PR modernizes the WRF-Chem reader and introduces a new generalized GRIB2 reader using the `grib2io` engine, adhering to the Aero Protocol.

Key changes:
- **WRF-Chem**: Refactored to support lazy processing (Dask). Implemented lazy character array parsing for `Times` using `xr.apply_ufunc` and lazy unit conversions (ppmv to ppbV, and mass mixing ratio to concentration). Added NumPy-style docstrings and type hinting.
- **GRIB2**: Created a new `Grib2Reader` that leverages `grib2io` via Xarray. Includes harmonization logic to standardize coordinate names (`latitude`, `longitude`, `time`) and metadata.
- **Integration**: Updated `monetio/__init__.py` to support lazy loading of the new `wrfchem` and `grib2` readers.
- **Testing**: Added `tests/test_aero_wrfchem.py`, `tests/test_aero_grib2.py`, and `tests/test_aero_load.py` to verify logic on both Eager (NumPy) and Lazy (Dask) data backends.


---
*PR created automatically by Jules for task [12530383575988378723](https://jules.google.com/task/12530383575988378723) started by @bbakernoaa*