### PR TITLE
Standardize point reader output for UGRID 1.0 compliance

### DIFF
--- a/monetio/readers/base.py
+++ b/monetio/readers/base.py
@@ -229,14 +229,20 @@ class PointReader(BaseReader):
 
         # Add UGRID metadata
         if "node" in ds.dims:
-            ds["mesh"] = xr.DataArray(
-                data=np.int32(0),
-                attrs={
-                    "cf_role": "mesh_topology",
-                    "topology_dimension": 0,
-                    "node_coordinates": "longitude latitude",
-                },
-            )
+            node_coords = []
+            for c in ["longitude", "latitude", "elevation"]:
+                if c in ds.coords:
+                    node_coords.append(c)
+
+            if node_coords:
+                ds["mesh"] = xr.DataArray(
+                    data=np.int32(0),
+                    attrs={
+                        "cf_role": "mesh_topology",
+                        "topology_dimension": 0,
+                        "node_coordinates": " ".join(node_coords),
+                    },
+                )
 
             if "latitude" in ds.coords:
                 ds.coords["latitude"].attrs.update(
@@ -246,10 +252,20 @@ class PointReader(BaseReader):
                 ds.coords["longitude"].attrs.update(
                     {"units": "degrees_east", "standard_name": "longitude"}
                 )
+            if "elevation" in ds.coords:
+                ds.coords["elevation"].attrs.update(
+                    {"units": "m", "standard_name": "height_above_mean_sea_level"}
+                )
 
             for var in ds.data_vars:
                 if "node" in ds[var].dims:
                     ds[var].attrs.update({"mesh": "mesh", "location": "node"})
+
+        # Add Global Attributes
+        if "Conventions" not in ds.attrs:
+            ds.attrs["Conventions"] = "CF-1.8 UGRID-1.0"
+        elif "UGRID-1.0" not in ds.attrs["Conventions"]:
+            ds.attrs["Conventions"] += " UGRID-1.0"
 
         # Update history
         history = (

--- a/monetio/util.py
+++ b/monetio/util.py
@@ -660,10 +660,12 @@ def ds_to_2d(ds, pivot=True, fixed_location=False):
         # but we rename it to 'node' for UGRID compliance.
         if "siteid" in ds2d.dims:
             # Preserve siteid as a coordinate while renaming dimension to node for UGRID compliance
-            # siteids = ds2d.siteid.values  # Store values for restoration
             ds2d = ds2d.rename({"siteid": "node"})
-            # After renaming, node contains site IDs. Add siteid back as coord.
-            ds2d.coords["siteid"] = (("node",), ds2d.node.values)
+            # Now 'node' has siteid values.
+            # We want 'node' to be 0...N-1 and 'siteid' to be a coordinate of 'node'.
+            siteids = ds2d.node.values
+            ds2d.coords["siteid"] = (("node",), siteids)
+            ds2d.coords["node"] = (("node",), np.arange(ds2d.sizes["node"]))
 
         if fixed_location:
             # Enforce fixed locations by averaging over time (ignoring NaNs)

--- a/tests/test_aero_openaq.py
+++ b/tests/test_aero_openaq.py
@@ -56,8 +56,8 @@ def test_openaq_eager_lazy(tmp_path):
     assert ds_eager.pm25_ugm3.values[0] == 10.0
     # O3 conversion: 50 / 1990
     assert np.isclose(ds_eager.o3_ppm.values[0], 50.0 / 1990.0)
-    # siteid is renamed to node during 2D expansion
-    assert ds_eager.coords["node"].values[0].startswith("TS_")
+    # siteid is renamed to node during 2D expansion, but preserved as siteid coord
+    assert ds_eager.coords["siteid"].values[0].startswith("TS_")
 
     # Test Lazy Mode (Wide format)
     ds_lazy = reader.open_dataset(files=[str(f)], wide_fmt=True, as_xarray=True, lazy=True)

--- a/tests/test_aero_openaq_aws.py
+++ b/tests/test_aero_openaq_aws.py
@@ -31,11 +31,8 @@ def test_openaq_aws_eager_lazy(tmp_path):
     assert isinstance(ds_eager, xr.Dataset)
     assert "value" in ds_eager.data_vars
     assert ds_eager.value.values[0] == 10.0
-    # siteid should be in coords or node
-    if "siteid" in ds_eager.coords:
-        assert ds_eager.coords["siteid"].values[0] == "2178"
-    else:
-        assert ds_eager.coords["node"].values[0] == "2178"
+    # siteid should be in coords
+    assert ds_eager.coords["siteid"].values[0] == "2178"
 
     # Test Lazy Mode
     ds_lazy = reader.open_dataset(files=[str(f)], as_xarray=True, lazy=True)

--- a/tests/test_aero_pams.py
+++ b/tests/test_aero_pams.py
@@ -38,8 +38,8 @@ def test_pams_eager_lazy(tmp_path):
     assert isinstance(ds_eager, xr.Dataset)
     assert "obs" in ds_eager.data_vars
     assert ds_eager.obs.values[0] == 10.0
-    # siteid is renamed to node during 2D expansion
-    assert ds_eager.coords["node"].values[0] == "010010001"
+    # siteid is renamed to node during 2D expansion, but preserved as siteid coord
+    assert ds_eager.coords["siteid"].values[0] == "010010001"
 
     # Test Lazy Mode
     ds_lazy = reader.open_dataset(files=[str(f)], as_xarray=True, lazy=True)

--- a/tests/test_openaq_aero.py
+++ b/tests/test_openaq_aero.py
@@ -43,8 +43,8 @@ def test_openaq_eager_lazy(tmp_path):
         assert isinstance(ds_eager, xr.Dataset)
         assert "pm25_ugm3" in ds_eager.data_vars
         assert ds_eager.pm25_ugm3.values[0] == 10.0
-        # siteid is renamed to node during 2D expansion
-        assert ds_eager.coords["node"].values[0].startswith("TS_")
+        # siteid is renamed to node during 2D expansion, but preserved as siteid coord
+        assert ds_eager.coords["siteid"].values[0].startswith("TS_")
 
         # Lazy Mode
         ds_lazy = reader.open_dataset(dates="2023-01-01", wide_fmt=True, as_xarray=True, lazy=True)


### PR DESCRIPTION
This change ensures that all point observation readers in monetio produce Xarray Datasets that are fully compliant with UGRID 1.0 and CF conventions. It standardizes the dimension structure (integer-indexed node dimension) and adds the necessary attributes for mesh topology and coordinate linkage.

---
*PR created automatically by Jules for task [13747547669577454397](https://jules.google.com/task/13747547669577454397) started by @bbakernoaa*