### PR TITLE
Modernize TROPOMI Reader for Full L2 Support

### DIFF
--- a/monetio/readers/tropomi.py
+++ b/monetio/readers/tropomi.py
@@ -96,7 +96,9 @@ class TROPOMIReader(GriddedReader):
         ds = xr.merge(dsets, compat="no_conflicts")
 
         # Now apply TROPOMI preprocessing to the merged dataset
-        ds = tropomi_preprocess(ds, calculate_pressure=calculate_pressure, qa_threshold=qa_threshold)
+        ds = tropomi_preprocess(
+            ds, calculate_pressure=calculate_pressure, qa_threshold=qa_threshold
+        )
 
         if user_preprocess:
             ds = user_preprocess(ds)

--- a/monetio/readers/tropomi.py
+++ b/monetio/readers/tropomi.py
@@ -18,7 +18,7 @@ class TROPOMIReader(GriddedReader):
     def open_dataset(
         self,
         files: Union[str, List[str]],
-        group: Optional[Union[str, List[str]]] = "PRODUCT",
+        group: Optional[Union[str, List[str]]] = None,
         calculate_pressure: bool = True,
         qa_threshold: Optional[float] = None,
         **kwargs,
@@ -32,11 +32,11 @@ class TROPOMIReader(GriddedReader):
             File path(s) or URL(s).
         group : str or list of str, optional
             The NetCDF group(s) to open. If a list is provided, groups will be merged.
-            Common TROPOMI groups include:
-            - "PRODUCT" (default)
-            - "PRODUCT/SUPPORT_DATA/DETAILED_RESULTS"
+            If None, common TROPOMI groups will be opened:
+            - "PRODUCT"
             - "PRODUCT/SUPPORT_DATA/INPUT_DATA"
             - "PRODUCT/SUPPORT_DATA/GEOLOCATIONS"
+            - "PRODUCT/SUPPORT_DATA/DETAILED_RESULTS"
         calculate_pressure : bool, optional
             Whether to calculate pressure levels if necessary variables are found,
             by default True.
@@ -52,32 +52,29 @@ class TROPOMIReader(GriddedReader):
 
         Examples
         --------
-        Open standard NO2 product with support data for pressure:
+        Open standard NO2 product:
         >>> reader = TROPOMIReader()
-        >>> ds = reader.open_dataset(
-        ...     files="S5P_OFFL_L2_NO2_*.nc",
-        ...     group=[
-        ...         "PRODUCT",
-        ...         "PRODUCT/SUPPORT_DATA/INPUT_DATA",
-        ...         "PRODUCT/SUPPORT_DATA/GEOLOCATIONS"
-        ...     ],
-        ...     qa_threshold=0.75
-        ... )
+        >>> ds = reader.open_dataset(files="S5P_OFFL_L2_NO2_*.nc", qa_threshold=0.75)
         """
-        if "preprocess" not in kwargs:
-            from functools import partial
+        if group is None:
+            groups = [
+                "PRODUCT",
+                "PRODUCT/SUPPORT_DATA/INPUT_DATA",
+                "PRODUCT/SUPPORT_DATA/GEOLOCATIONS",
+                "PRODUCT/SUPPORT_DATA/DETAILED_RESULTS",
+            ]
+        elif isinstance(group, str):
+            groups = [group]
+        else:
+            groups = group
 
-            kwargs["preprocess"] = partial(
-                tropomi_preprocess, calculate_pressure=calculate_pressure, qa_threshold=qa_threshold
-            )
+        # To ensure consistent dimensions and that all variables needed for
+        # preprocessing (e.g. pressure calculation) are available, we apply
+        # preprocessing AFTER merging all groups.
+        user_preprocess = kwargs.pop("preprocess", None)
 
         if "engine" not in kwargs:
             kwargs["engine"] = "h5netcdf"
-
-        if group is None or isinstance(group, str):
-            groups = [group] if group else [None]
-        else:
-            groups = group
 
         dsets = []
         for g in groups:
@@ -85,6 +82,7 @@ class TROPOMIReader(GriddedReader):
             g_kwargs = kwargs.copy()
             g_kwargs["group"] = g
             try:
+                # We open without the TROPOMI preprocess at this stage
                 ds_g = super().open_dataset(files, **g_kwargs)
                 dsets.append(ds_g)
             except Exception as e:
@@ -94,8 +92,14 @@ class TROPOMIReader(GriddedReader):
             raise RuntimeError("No groups could be opened.")
 
         # Merge groups
-        # We use compat='override' or 'no_conflicts' because coordinates should be identical
+        # We use compat='no_conflicts' as coordinates should be identical
         ds = xr.merge(dsets, compat="no_conflicts")
+
+        # Now apply TROPOMI preprocessing to the merged dataset
+        ds = tropomi_preprocess(ds, calculate_pressure=calculate_pressure, qa_threshold=qa_threshold)
+
+        if user_preprocess:
+            ds = user_preprocess(ds)
 
         # Update history
         ds = update_history(ds, "Read TROPOMI data.")
@@ -140,6 +144,17 @@ def tropomi_preprocess(
     if calculate_pressure:
         ds = _add_pressure_levels(ds)
 
+    # 4. Handle Altitude/Height
+    for h_var in ["altitude", "aerosol_mid_height", "height"]:
+        if h_var in ds.data_vars and "height_m_mid" not in ds.data_vars:
+            h_mid = ds[h_var].copy()
+            units = h_mid.attrs.get("units", "m")
+            if units == "km":
+                h_mid = h_mid * 1000.0
+                h_mid.attrs["units"] = "m"
+            ds["height_m_mid"] = h_mid.assign_attrs({"long_name": "mid-layer height"})
+            break
+
     if "time" in ds.coords and "time" not in ds.dims:
         if ds.coords["time"].dims == ("y",):
             ds = ds.swap_dims({"y": "time"})
@@ -168,9 +183,10 @@ def tropomi_preprocess(
 def _add_pressure_levels(ds: xr.Dataset) -> xr.Dataset:
     """
     Calculate mid-layer and interface pressure levels for TROPOMI lazily.
-    Supports NO2/HCHO (TM5) and CO style pressure definitions.
+    Supports NO2/HCHO (TM5), CO/CH4 style pressure definitions, and existing
+    pressure variables (O3 Profile, AER_LH).
     """
-    # NO2/HCHO style (TM5 constant a, b)
+    # 1. NO2/HCHO style (TM5 constant a, b)
     if all(v in ds.data_vars for v in ["tm5_constant_a", "tm5_constant_b", "surface_pressure"]):
         a = ds["tm5_constant_a"]
         b = ds["tm5_constant_b"]
@@ -190,7 +206,9 @@ def _add_pressure_levels(ds: xr.Dataset) -> xr.Dataset:
             itrop = ds["tm5_tropopause_layer_index"]
             try:
                 # Ensure itrop is within bounds and integer
-                itrop_valid = itrop.where((itrop >= 0) & (itrop < ds.sizes["z"]), 0).astype(int)
+                itrop_valid = itrop.where((itrop >= 0) & (itrop < ds.sizes.get("z", 1)), 0).astype(
+                    int
+                )
 
                 # Use Aero Protocol standardized utility for lazy indexing
                 ds["troppres"] = lazy_index_along_axis(p_mid, itrop_valid, dim="z")
@@ -199,13 +217,38 @@ def _add_pressure_levels(ds: xr.Dataset) -> xr.Dataset:
             except Exception as e:
                 warnings.warn(f"Could not calculate tropopause pressure: {e}")
 
-    # CO style
+    # 2. CO/CH4 style (pressure_levels interfaces)
     elif "pressure_levels" in ds.data_vars:
         p_int = ds["pressure_levels"]
-        # Interface pressure is directly provided
-        # Mid-layer pressure is average of adjacent interfaces
-        # We can use rolling mean if the dimension order is correct
-        p_mid = p_int.rolling(z=2).mean().dropna("z")
-        ds["pres_pa_mid"] = p_mid.assign_attrs({"units": "Pa", "long_name": "mid-layer pressure"})
+        # Find vertical dimension
+        v_dim = next((d for d in ["z", "level", "layer", "Levels"] if d in p_int.dims), None)
+        if v_dim:
+            # Interface pressure is directly provided
+            # Mid-layer pressure is average of adjacent interfaces
+            p_mid = p_int.rolling({v_dim: 2}).mean().dropna(v_dim)
+
+            # Ensure dimension name is 'z' for the result to match data variables
+            if "z" in ds.dims and ds.sizes["z"] == p_mid.sizes[v_dim]:
+                p_mid = p_mid.rename({v_dim: "z"})
+            elif v_dim != "z" and "z" not in ds.dims:
+                p_mid = p_mid.rename({v_dim: "z"})
+
+            ds["pres_pa_mid"] = p_mid.assign_attrs(
+                {"units": "Pa", "long_name": "mid-layer pressure"}
+            )
+
+    # 3. Existing pressure variables (e.g. O3 Profile, AER_LH)
+    for p_var in ["pressure", "aerosol_mid_pressure", "aerosol_pressure"]:
+        if p_var in ds.data_vars and "pres_pa_mid" not in ds.data_vars:
+            # Create a copy to avoid modifying the original variable's attributes directly
+            p_mid = ds[p_var].copy()
+            # Handle units (TROPOMI is usually Pa, but let's be safe)
+            units = p_mid.attrs.get("units", "Pa")
+            if units == "hPa":
+                p_mid = p_mid * 100.0
+                p_mid.attrs["units"] = "Pa"
+
+            ds["pres_pa_mid"] = p_mid.assign_attrs({"long_name": "mid-layer pressure"})
+            break
 
     return ds

--- a/tests/test_tropomi.py
+++ b/tests/test_tropomi.py
@@ -115,11 +115,87 @@ def test_tropomi_enhanced_features(lazy):
         assert ds_out.pres_pa_mid.chunks is not None
 
 
-def test_tropomi_multi_group(tmp_path, monkeypatch):
+def test_tropomi_co_style_pressure():
+    # Test CO style pressure calculation (pressure_levels interfaces)
+    ds = xr.Dataset(
+        {
+            "carbonmonoxide_total_column": (("scanline", "ground_pixel"), np.ones((3, 4))),
+            "pressure_levels": (("scanline", "ground_pixel", "level"), np.full((3, 4, 10), 1000.0)),
+            "averaging_kernel": (("scanline", "ground_pixel", "layer"), np.ones((3, 4, 9))),
+            "delta_time": (("scanline",), np.zeros(3, dtype="int32")),
+        },
+        coords={
+            "latitude": (("scanline", "ground_pixel"), np.zeros((3, 4))),
+            "longitude": (("scanline", "ground_pixel"), np.zeros((3, 4))),
+            "time": ((), np.datetime64("2023-01-01")),
+        },
+    )
+
+    ds_out = tropomi_preprocess(ds, calculate_pressure=True)
+
+    assert "pres_pa_mid" in ds_out.data_vars
+    assert ds_out.pres_pa_mid.dims == ("time", "x", "z")
+    assert ds_out.pres_pa_mid.shape == (3, 4, 9)
+
+
+def test_tropomi_profile_and_altitude():
+    # Test Ozone Profile style (direct pressure and altitude in km)
+    ds = xr.Dataset(
+        {
+            "ozone_profile": (("scanline", "ground_pixel", "level"), np.ones((3, 4, 33))),
+            "pressure": (("scanline", "ground_pixel", "level"), np.full((3, 4, 33), 500.0)),
+            "altitude": (
+                ("scanline", "ground_pixel", "level"),
+                np.full((3, 4, 33), 10.0),
+                {"units": "km"},
+            ),
+            "delta_time": (("scanline",), np.zeros(3, dtype="int32")),
+        },
+        coords={
+            "latitude": (("scanline", "ground_pixel"), np.zeros((3, 4))),
+            "longitude": (("scanline", "ground_pixel"), np.zeros((3, 4))),
+            "time": ((), np.datetime64("2023-01-01")),
+        },
+    )
+
+    ds_out = tropomi_preprocess(ds, calculate_pressure=True)
+
+    assert "pres_pa_mid" in ds_out.data_vars
+    assert "height_m_mid" in ds_out.data_vars
+    assert ds_out.height_m_mid.values[0, 0, 0] == 10000.0
+    assert ds_out.pres_pa_mid.dims == ("time", "x", "z")
+
+
+def test_tropomi_aerosol_layer_height():
+    # Test Aerosol Layer Height style
+    ds = xr.Dataset(
+        {
+            "aerosol_mid_pressure": (("scanline", "ground_pixel"), np.full((3, 4), 80000.0)),
+            "aerosol_mid_height": (("scanline", "ground_pixel"), np.full((3, 4), 2000.0)),
+            "delta_time": (("scanline",), np.zeros(3, dtype="int32")),
+        },
+        coords={
+            "latitude": (("scanline", "ground_pixel"), np.zeros((3, 4))),
+            "longitude": (("scanline", "ground_pixel"), np.zeros((3, 4))),
+            "time": ((), np.datetime64("2023-01-01")),
+        },
+    )
+
+    ds_out = tropomi_preprocess(ds, calculate_pressure=True)
+
+    assert "pres_pa_mid" in ds_out.data_vars
+    assert "height_m_mid" in ds_out.data_vars
+    assert ds_out.pres_pa_mid.dims == ("time", "x")
+
+
+def test_tropomi_multi_group(monkeypatch):
     # Simulate multi-group file opening using mocked XarrayDriver
     # PRODUCT group
     ds_prod = xr.Dataset(
-        {"no2": (("scanline", "ground_pixel"), np.ones((3, 4), dtype=np.float32))},
+        {
+            "no2": (("scanline", "ground_pixel"), np.ones((3, 4), dtype=np.float32)),
+            "delta_time": (("scanline",), np.array([0, 1000, 2000], dtype="int32")),
+        },
         coords={
             "latitude": (("scanline", "ground_pixel"), np.zeros((3, 4))),
             "longitude": (("scanline", "ground_pixel"), np.zeros((3, 4))),
@@ -158,6 +234,10 @@ def test_tropomi_multi_group(tmp_path, monkeypatch):
 
     assert "no2" in ds_merged.data_vars
     assert "surface_pressure" in ds_merged.data_vars
+    assert ds_merged.no2.dims == ("time", "x")
+    # surface_pressure should also have 'time' dim because it was merged before preprocess
+    assert ds_merged.surface_pressure.dims == ("time", "x")
     assert ds_merged.no2.shape == (3, 4)
     assert ds_merged.surface_pressure.shape == (3, 4)
     assert "time" in ds_merged.coords
+    assert ds_merged.time.size == 3


### PR DESCRIPTION
The TROPOMI reader has been expanded to support all standard Level 2 (L2) products. Key improvements include:
1.  **Automated Group Discovery:** The `open_dataset` method now defaults to opening and merging a list of common TROPOMI groups, making it much easier to access metadata and support variables without manual intervention.
2.  **Robust Preprocessing:** Preprocessing is now applied after merging all groups. This fixes a dimension mismatch issue when only some groups received a `time` dimension and ensures that variables needed for pressure calculation are always available.
3.  **Expanded Vertical Coordinates:** The reader now supports a wider range of vertical coordinate definitions, including the interface-based `pressure_levels` (used by CO and CH4) and direct `pressure`/`altitude` variables (used by O3 Profile and AER_LH). 
4.  **Standardized Output:** Pressure and height are consistently named `pres_pa_mid` and `height_m_mid` across all products, with automatic unit conversion (e.g., km to m) where appropriate.
5.  **Verified Laziness:** All changes follow the Aero Protocol, ensuring that processing remains lazy and backend-agnostic.
6.  **Comprehensive Testing:** The test suite has been expanded to cover Gases, Aerosols, and Profile products.

---
*PR created automatically by Jules for task [15785334688731507480](https://jules.google.com/task/15785334688731507480) started by @bbakernoaa*