### PR TITLE
Fix multi-site resampling and standardize ISH/ISH Lite readers

### DIFF
--- a/monetio/readers/ish.py
+++ b/monetio/readers/ish.py
@@ -331,7 +331,7 @@ class ISHReader(PointReader):
         download: bool = False,
         n_procs: int = 1,
         verbose: bool = False,
-        source: str = "aws",
+        source: Optional[str] = None,
         as_xarray: bool = True,
         lazy: bool = False,
         **kwargs,
@@ -388,7 +388,8 @@ class ISHReader(PointReader):
             raise ValueError("Only one of `box`, `country`, `state`, or `site` can be used")
 
         ish = ISH()
-        ish.source = source
+        if source is not None:
+            ish.source = source
 
         if files is None and dates is not None:
             dates = pd.to_datetime(dates)

--- a/monetio/readers/ish.py
+++ b/monetio/readers/ish.py
@@ -148,7 +148,10 @@ class ISH:
         furls = []
 
         if lite:
-            url = "https://www.ncei.noaa.gov/pub/data/noaa/isd-lite"
+            if self.source == "aws":
+                url = "s3://noaa-isd-pds/isd-lite/data"
+            else:
+                url = "https://www.ncei.noaa.gov/pub/data/noaa/isd-lite"
         elif self.source == "aws":
             url = "s3://noaa-isd-pds/data"
         else:

--- a/monetio/readers/ish.py
+++ b/monetio/readers/ish.py
@@ -224,14 +224,15 @@ def read_ish_file(fname: str, **kwargs) -> pd.DataFrame:
     Parameters
     ----------
     fname : str
-        File path or URL.
+        File path, URL, or fsspec-compatible path.
     **kwargs : dict
-        Additional arguments.
+        Additional arguments passed to FileUtility.get_fs and read_csv.
+        Includes `request_retries`, `request_timeout`, and `storage_options`.
 
     Returns
     -------
     pd.DataFrame
-        The loaded data.
+        The loaded data in long format.
     """
     # Regression fix: check valid retries
     request_retries = kwargs.get("request_retries", 3)
@@ -333,7 +334,7 @@ class ISHReader(PointReader):
         **kwargs,
     ) -> Union[pd.DataFrame, xr.Dataset, "dd.DataFrame"]:
         """
-        Retrieve and load ISH (Integrated Surface Hourly) data .
+        Retrieve and load ISH (Integrated Surface Hourly) data.
 
         Parameters
         ----------
@@ -360,18 +361,24 @@ class ISHReader(PointReader):
         verbose : bool, optional
             Whether to print verbose output, by default False.
         source : str, optional
-            Data source: 'ncdc' or 'aws', by default 'ncdc'.
+            Data source: 'ncdc' or 'aws', by default 'aws'.
         as_xarray : bool, optional
             Whether to return an xarray.Dataset, by default True.
         lazy : bool, optional
             Whether to return a dask-backed object, by default False.
         **kwargs : dict
-            Additional arguments.
+            Additional arguments passed to the driver or to_xarray.
 
         Returns
         -------
         Union[pd.DataFrame, xr.Dataset, dd.DataFrame]
             The loaded ISH data.
+
+        Examples
+        --------
+        >>> from monetio.readers.ish import ISHReader
+        >>> reader = ISHReader()
+        >>> ds = reader.open_dataset(dates='2021-08-01', site='72406093721')
         """
         # Regression fix: check multiple subsets
         if sum([box is not None, country is not None, state is not None, site is not None]) > 1:
@@ -445,6 +452,8 @@ class ISHReader(PointReader):
             df = df.compute(num_workers=n_procs)
 
         if as_xarray:
+            from ..util import ds_to_2d
+
             # We first convert to 1D
             ds = self.to_xarray(df, expand2d=False, **kwargs)
 
@@ -464,8 +473,6 @@ class ISHReader(PointReader):
             if resample:
                 # Backend-agnostic resampling in xarray
                 # To preserve per-site data, we expand to 2D (time, node) before resampling
-                from ..util import ds_to_2d
-
                 pivot = kwargs.get("wide_fmt", kwargs.get("pivot", True))
                 ds = ds_to_2d(ds, pivot=pivot, fixed_location=self.fixed_location)
 
@@ -489,16 +496,15 @@ class ISHReader(PointReader):
                 for c in metadata.coords:
                     ds.coords[c] = metadata.coords[c]
                 if "siteid" not in ds.coords and "siteid" not in ds.data_vars and "node" in ds.dims:
-                    ds.coords["siteid"] = (("node",), ds.node.values)
+                    ds.coords["siteid"] = (("node",), ds.node.data)
 
-                ds = ds.set_coords([c for c in meta_coords if c in ds.data_vars])
+                # Update history for resampling
+                ds = update_history(ds, f"Resampled ISH data to {window} window.")
 
             else:
                 # Now expand to 2D if requested (default is True in PointReader)
                 expand2d = kwargs.get("expand2d", True)
                 if expand2d:
-                    from ..util import ds_to_2d
-
                     pivot = kwargs.get("wide_fmt", kwargs.get("pivot", True))
                     ds = ds_to_2d(ds, pivot=pivot, fixed_location=self.fixed_location)
                     if (
@@ -506,7 +512,10 @@ class ISHReader(PointReader):
                         and "siteid" not in ds.data_vars
                         and "node" in ds.dims
                     ):
-                        ds.coords["siteid"] = (("node",), ds.node.values)
+                        ds.coords["siteid"] = (("node",), ds.node.data)
+
+            # Ensure metadata are coordinates
+            ds = ds.set_coords([c for c in meta_coords if c in ds.variables])
 
             # Update history
             ds = update_history(ds, "Read ISH data.")

--- a/monetio/readers/ish_lite.py
+++ b/monetio/readers/ish_lite.py
@@ -20,17 +20,19 @@ from .sat_utils import update_history
 
 def read_ish_lite_file(fname: str, **kwargs) -> pd.DataFrame:
     """
-    Read a single ISH Lite file.
+    Read a single ISH (Integrated Surface Hourly) Lite file.
 
     Parameters
     ----------
     fname : str
-        File path or URL.
+        File path, URL, or fsspec-compatible path.
+    **kwargs : dict
+        Additional arguments passed to fsspec.open.
 
     Returns
     -------
     pd.DataFrame
-        The loaded data.
+        The loaded data in long format.
     """
     from numpy import nan
 
@@ -93,7 +95,7 @@ class ISHLiteReader(PointReader):
         **kwargs,
     ) -> Union[pd.DataFrame, xr.Dataset, "dd.DataFrame"]:
         """
-        Retrieve and load ISH (Integrated Surface Hourly) Lite data .
+        Retrieve and load ISH (Integrated Surface Hourly) Lite data.
 
         Parameters
         ----------
@@ -120,14 +122,21 @@ class ISHLiteReader(PointReader):
         as_xarray : bool, optional
             Whether to return an xarray.Dataset, by default True.
         lazy : bool, optional
-            Whether to return a dask-backed object, by default False.
+            Whether to return a dask-backed object (dask.dataframe or xarray with dask),
+            by default False.
         **kwargs : dict
-            Additional arguments.
+            Additional arguments passed to the driver or to_xarray.
 
         Returns
         -------
         Union[pd.DataFrame, xr.Dataset, dd.DataFrame]
             The loaded ISH Lite data.
+
+        Examples
+        --------
+        >>> from monetio.readers.ish_lite import ISHLiteReader
+        >>> reader = ISHLiteReader()
+        >>> ds = reader.open_dataset(dates='2021-08-01', site='72406093721')
         """
         ish = ISH()
 
@@ -197,9 +206,12 @@ class ISHLiteReader(PointReader):
             df = df.compute(num_workers=n_procs)
 
         if as_xarray:
-            ds = self.to_xarray(df, **kwargs)
+            from ..util import ds_to_2d
 
-            # Preserve metadata in coordinates during resampling
+            # We first convert to 1D UGRID
+            ds = self.to_xarray(df, expand2d=False, **kwargs)
+
+            # Metadata variables to preserve
             meta_coords = [
                 "country",
                 "state",
@@ -208,15 +220,59 @@ class ISHLiteReader(PointReader):
                 "latitude",
                 "longitude",
                 "siteid",
+                "usaf",
+                "wban",
             ]
-            ds = ds.set_coords([c for c in meta_coords if c in ds.data_vars])
 
             if resample:
                 # Backend-agnostic resampling in xarray
+                # To preserve per-site data, we expand to 2D (time, node) before resampling
+                pivot = kwargs.get("wide_fmt", kwargs.get("pivot", True))
+                ds = ds_to_2d(ds, pivot=pivot, fixed_location=self.fixed_location)
+
+                # Identify metadata variables to preserve (those that don't vary with time)
+                metadata = xr.Dataset()
+                for c in meta_coords:
+                    if c in ds.coords or c in ds.data_vars:
+                        val = ds[c]
+                        if "time" in val.dims:
+                            # If it varies with time, we take the first value per node
+                            val = val.isel(time=0, drop=True)
+                        metadata[c] = val
+
                 try:
-                    ds = ds.resample(time=window).mean(numeric_only=True)
-                except TypeError:
-                    ds = ds.resample(time=window).mean()
+                    ds = ds.sortby("time").resample(time=window).mean(numeric_only=True)
+                except Exception:
+                    ds = ds.sortby("time").resample(time=window).mean()
+
+                # Restore metadata
+                for c in metadata.data_vars:
+                    ds[c] = metadata[c]
+                for c in metadata.coords:
+                    ds.coords[c] = metadata.coords[c]
+
+                # Ensure siteid is correctly linked to node if it's the dimension
+                if "siteid" not in ds.coords and "siteid" not in ds.data_vars and "node" in ds.dims:
+                    ds.coords["siteid"] = (("node",), ds.node.data)
+
+                # Update history for resampling
+                ds = update_history(ds, f"Resampled ISH Lite data to {window} window.")
+
+            else:
+                # Now expand to 2D if requested (default is True in PointReader)
+                expand2d = kwargs.get("expand2d", True)
+                if expand2d:
+                    pivot = kwargs.get("wide_fmt", kwargs.get("pivot", True))
+                    ds = ds_to_2d(ds, pivot=pivot, fixed_location=self.fixed_location)
+                    if (
+                        "siteid" not in ds.coords
+                        and "siteid" not in ds.data_vars
+                        and "node" in ds.dims
+                    ):
+                        ds.coords["siteid"] = (("node",), ds.node.data)
+
+            # Ensure metadata are coordinates
+            ds = ds.set_coords([c for c in meta_coords if c in ds.variables])
 
             # Update history
             ds = update_history(ds, "Read ISH Lite data.")
@@ -265,7 +321,39 @@ def add_data(
     **kwargs,
 ) -> Union[pd.DataFrame, xr.Dataset, "dd.DataFrame"]:
     """
-    Backward-compatible wrapper for ISHLiteReader.open_dataset.
+    Retrieve and load ISH Lite data (backward-compatible wrapper).
+
+    Parameters
+    ----------
+    dates : Union[pd.DatetimeIndex, List[datetime], datetime, str]
+        Dates to retrieve.
+    box : List[float], optional
+        Bounding box [latmin, lonmin, latmax, lonmax].
+    country : str, optional
+        Country code.
+    state : str, optional
+        State code.
+    site : str, optional
+        Station ID.
+    resample : bool, optional
+        Whether to resample, by default False.
+    window : str, optional
+        Resampling window, by default 'h'.
+    n_procs : int, optional
+        Number of processors, by default 1.
+    verbose : bool, optional
+        Verbose output, by default False.
+    as_xarray : bool, optional
+        Return xarray.Dataset, by default True.
+    lazy : bool, optional
+        Return dask-backed object, by default False.
+    **kwargs : dict
+        Additional arguments.
+
+    Returns
+    -------
+    Union[pd.DataFrame, xr.Dataset, dd.DataFrame]
+        The loaded ISH Lite data.
     """
     return ISHLiteReader().open_dataset(
         dates=dates,

--- a/monetio/readers/ish_lite.py
+++ b/monetio/readers/ish_lite.py
@@ -90,6 +90,7 @@ class ISHLiteReader(PointReader):
         window: str = "h",
         n_procs: int = 1,
         verbose: bool = False,
+        source: str = "aws",
         as_xarray: bool = True,
         lazy: bool = False,
         **kwargs,
@@ -119,6 +120,8 @@ class ISHLiteReader(PointReader):
             Number of processors for dask compute (if not lazy), by default 1.
         verbose : bool, optional
             Whether to print verbose output, by default False.
+        source : str, optional
+            Data source: 'ncdc' or 'aws', by default 'aws'.
         as_xarray : bool, optional
             Whether to return an xarray.Dataset, by default True.
         lazy : bool, optional
@@ -139,6 +142,7 @@ class ISHLiteReader(PointReader):
         >>> ds = reader.open_dataset(dates='2021-08-01', site='72406093721')
         """
         ish = ISH()
+        ish.source = source
 
         if files is None and dates is not None:
             dates = pd.to_datetime(dates)
@@ -316,6 +320,7 @@ def add_data(
     window: str = "h",
     n_procs: int = 1,
     verbose: bool = False,
+    source: str = "aws",
     as_xarray: bool = True,
     lazy: bool = False,
     **kwargs,
@@ -343,6 +348,8 @@ def add_data(
         Number of processors, by default 1.
     verbose : bool, optional
         Verbose output, by default False.
+    source : str, optional
+        Data source: 'ncdc' or 'aws', by default 'aws'.
     as_xarray : bool, optional
         Return xarray.Dataset, by default True.
     lazy : bool, optional
@@ -365,6 +372,7 @@ def add_data(
         window=window,
         n_procs=n_procs,
         verbose=verbose,
+        source=source,
         as_xarray=as_xarray,
         lazy=lazy,
         **kwargs,

--- a/monetio/readers/ish_lite.py
+++ b/monetio/readers/ish_lite.py
@@ -90,7 +90,7 @@ class ISHLiteReader(PointReader):
         window: str = "h",
         n_procs: int = 1,
         verbose: bool = False,
-        source: str = "aws",
+        source: Optional[str] = None,
         as_xarray: bool = True,
         lazy: bool = False,
         **kwargs,
@@ -142,7 +142,8 @@ class ISHLiteReader(PointReader):
         >>> ds = reader.open_dataset(dates='2021-08-01', site='72406093721')
         """
         ish = ISH()
-        ish.source = source
+        if source is not None:
+            ish.source = source
 
         if files is None and dates is not None:
             dates = pd.to_datetime(dates)
@@ -320,7 +321,7 @@ def add_data(
     window: str = "h",
     n_procs: int = 1,
     verbose: bool = False,
-    source: str = "aws",
+    source: Optional[str] = None,
     as_xarray: bool = True,
     lazy: bool = False,
     **kwargs,

--- a/tests/test_aero_ish_lite_multi_site.py
+++ b/tests/test_aero_ish_lite_multi_site.py
@@ -1,8 +1,9 @@
+import numpy as np
 import pandas as pd
 import pytest
-import xarray as xr
-import numpy as np
+
 from monetio.readers.ish_lite import ISHLiteReader
+
 
 @pytest.fixture
 def mock_ish_lite_files(tmp_path):
@@ -18,11 +19,13 @@ def mock_ish_lite_files(tmp_path):
     content2 += "2023 01 01 01  220  90 10135  280   60 0 0 0\n"
 
     import gzip
+
     with gzip.open(fn1, "wb") as f:
         f.write(content1.encode())
     with gzip.open(fn2, "wb") as f:
         f.write(content2.encode())
     return [str(fn1), str(fn2)]
+
 
 def test_ish_lite_multi_site_resample(mock_ish_lite_files, monkeypatch):
     def mock_read_history(self, dates=None):
@@ -43,13 +46,16 @@ def test_ish_lite_multi_site_resample(mock_ish_lite_files, monkeypatch):
         )
 
     import monetio.readers.ish as ish
+
     monkeypatch.setattr(ish.ISH, "read_ish_history", mock_read_history)
 
     reader = ISHLiteReader()
 
     # 1. Eager with resample
     # resample='h' shouldn't change data as it's already hourly
-    ds = reader.open_dataset(files=mock_ish_lite_files, as_xarray=True, resample=True, window='h', lazy=False)
+    ds = reader.open_dataset(
+        files=mock_ish_lite_files, as_xarray=True, resample=True, window="h", lazy=False
+    )
 
     assert "node" in ds.dims
     assert ds.sizes["node"] == 2
@@ -73,6 +79,7 @@ def test_ish_lite_multi_site_resample(mock_ish_lite_files, monkeypatch):
     assert ds.latitude.isel(node=node_012345).values == 40.0
     assert ds.latitude.isel(node=node_543210).values == 41.0
 
+
 def test_ish_lite_multi_site_resample_lazy(mock_ish_lite_files, monkeypatch):
     def mock_read_history(self, dates=None):
         self.history = pd.DataFrame(
@@ -92,12 +99,15 @@ def test_ish_lite_multi_site_resample_lazy(mock_ish_lite_files, monkeypatch):
         )
 
     import monetio.readers.ish as ish
+
     monkeypatch.setattr(ish.ISH, "read_ish_history", mock_read_history)
 
     reader = ISHLiteReader()
 
     # 2. Lazy with resample
-    ds = reader.open_dataset(files=mock_ish_lite_files, as_xarray=True, resample=True, window='h', lazy=True)
+    ds = reader.open_dataset(
+        files=mock_ish_lite_files, as_xarray=True, resample=True, window="h", lazy=True
+    )
 
     assert ds.temp.chunks is not None
 
@@ -112,6 +122,7 @@ def test_ish_lite_multi_site_resample_lazy(mock_ish_lite_files, monkeypatch):
 
     assert ds_computed.temp.isel(time=0, node=node_012345).values == 10.0
     assert ds_computed.temp.isel(time=0, node=node_543210).values == 20.0
+
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/test_aero_ish_lite_multi_site.py
+++ b/tests/test_aero_ish_lite_multi_site.py
@@ -1,0 +1,117 @@
+import pandas as pd
+import pytest
+import xarray as xr
+import numpy as np
+from monetio.readers.ish_lite import ISHLiteReader
+
+@pytest.fixture
+def mock_ish_lite_files(tmp_path):
+    # Site 1
+    fn1 = tmp_path / "012345-67890-2023.gz"
+    # year month day hour temp dew_pt_temp press wdir ws sky_condition precip_1hr precip_6hr
+    content1 = "2023 01 01 00  100  50 10132  270   50 0 0 0\n"
+    content1 += "2023 01 01 01  110  60 10135  280   60 0 0 0\n"
+
+    # Site 2
+    fn2 = tmp_path / "543210-09876-2023.gz"
+    content2 = "2023 01 01 00  200  80 10132  270   50 0 0 0\n"
+    content2 += "2023 01 01 01  220  90 10135  280   60 0 0 0\n"
+
+    import gzip
+    with gzip.open(fn1, "wb") as f:
+        f.write(content1.encode())
+    with gzip.open(fn2, "wb") as f:
+        f.write(content2.encode())
+    return [str(fn1), str(fn2)]
+
+def test_ish_lite_multi_site_resample(mock_ish_lite_files, monkeypatch):
+    def mock_read_history(self, dates=None):
+        self.history = pd.DataFrame(
+            {
+                "usaf": ["012345", "543210"],
+                "wban": ["67890", "09876"],
+                "latitude": [40.0, 41.0],
+                "longitude": [-80.0, -81.0],
+                "station_id": ["01234567890", "54321009876"],
+                "ctry": ["US", "US"],
+                "state": ["PA", "OH"],
+                "station name": ["Test Station 1", "Test Station 2"],
+                "elev(m)": [100.0, 200.0],
+                "begin": [pd.to_datetime("2020-01-01"), pd.to_datetime("2020-01-01")],
+                "end": [pd.to_datetime("2025-01-01"), pd.to_datetime("2025-01-01")],
+            }
+        )
+
+    import monetio.readers.ish as ish
+    monkeypatch.setattr(ish.ISH, "read_ish_history", mock_read_history)
+
+    reader = ISHLiteReader()
+
+    # 1. Eager with resample
+    # resample='h' shouldn't change data as it's already hourly
+    ds = reader.open_dataset(files=mock_ish_lite_files, as_xarray=True, resample=True, window='h', lazy=False)
+
+    assert "node" in ds.dims
+    assert ds.sizes["node"] == 2
+    assert ds.sizes["time"] == 2
+
+    # Verify separate site data is preserved
+    # Site 1 at 00Z should be 10.0
+    # Site 2 at 00Z should be 20.0
+    # Before the fix, they might have been averaged into 15.0 if they shared a time slot in a 1D array
+    # But now they are separated by 'node' (siteid)
+
+    # Identify which node is which siteid
+    siteids = ds.siteid.values
+    node_012345 = np.where(siteids == "01234567890")[0][0]
+    node_543210 = np.where(siteids == "54321009876")[0][0]
+
+    assert ds.temp.isel(time=0, node=node_012345).values == 10.0
+    assert ds.temp.isel(time=0, node=node_543210).values == 20.0
+
+    # Verify metadata is preserved
+    assert ds.latitude.isel(node=node_012345).values == 40.0
+    assert ds.latitude.isel(node=node_543210).values == 41.0
+
+def test_ish_lite_multi_site_resample_lazy(mock_ish_lite_files, monkeypatch):
+    def mock_read_history(self, dates=None):
+        self.history = pd.DataFrame(
+            {
+                "usaf": ["012345", "543210"],
+                "wban": ["67890", "09876"],
+                "latitude": [40.0, 41.0],
+                "longitude": [-80.0, -81.0],
+                "station_id": ["01234567890", "54321009876"],
+                "ctry": ["US", "US"],
+                "state": ["PA", "OH"],
+                "station name": ["Test Station 1", "Test Station 2"],
+                "elev(m)": [100.0, 200.0],
+                "begin": [pd.to_datetime("2020-01-01"), pd.to_datetime("2020-01-01")],
+                "end": [pd.to_datetime("2025-01-01"), pd.to_datetime("2025-01-01")],
+            }
+        )
+
+    import monetio.readers.ish as ish
+    monkeypatch.setattr(ish.ISH, "read_ish_history", mock_read_history)
+
+    reader = ISHLiteReader()
+
+    # 2. Lazy with resample
+    ds = reader.open_dataset(files=mock_ish_lite_files, as_xarray=True, resample=True, window='h', lazy=True)
+
+    assert ds.temp.chunks is not None
+
+    ds_computed = ds.compute()
+
+    assert "node" in ds_computed.dims
+    assert ds_computed.sizes["node"] == 2
+
+    siteids = ds_computed.siteid.values
+    node_012345 = np.where(siteids == "01234567890")[0][0]
+    node_543210 = np.where(siteids == "54321009876")[0][0]
+
+    assert ds_computed.temp.isel(time=0, node=node_012345).values == 10.0
+    assert ds_computed.temp.isel(time=0, node=node_543210).values == 20.0
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
Fixed a bug in ISH and ISH Lite readers where multi-site data was incorrectly averaged during resampling. Standardized both readers to the Aero Protocol by improving documentation, history tracking, and maintaining lazy execution.

---
*PR created automatically by Jules for task [10156041002570352356](https://jules.google.com/task/10156041002570352356) started by @bbakernoaa*