### PR TITLE
Refactor EPA Readers with Unified Backend-Agnostic Utilities

### DIFF
--- a/monetio/readers/airnow.py
+++ b/monetio/readers/airnow.py
@@ -13,10 +13,10 @@ if TYPE_CHECKING:
     import dask.dataframe as dd
 from numpy import nan
 
-from ..util import force_object_strings, long_to_wide
+from ..util import long_to_wide
 from .base import PointReader, register_reader
 from .drivers import FileUtility
-from .epa_utils import read_monitor_file
+from .epa_utils import add_monitor_metadata
 from .sat_utils import update_history
 
 
@@ -545,32 +545,4 @@ def get_station_locations(
     Union[pd.DataFrame, dd.DataFrame]
         Dataframe with site metadata.
     """
-    # Check if dask
-    try:
-        import dask.dataframe as dd
-
-        is_dask = isinstance(df, dd.DataFrame)
-    except ImportError:
-        is_dask = False
-
-    monitor_df = read_monitor_file(airnow=True)
-
-    # To avoid "boolean value of NA is ambiguous" and merge warnings,
-    # we force string columns to 'object' (NumPy style) rather than nullable 'string'.
-    # This ensures bit-perfect matching in tests and avoids Dask/Pandas 3.0 discrepancies.
-    monitor_df = force_object_strings(monitor_df.drop_duplicates(subset=["siteid"]))
-
-    if is_dask:
-        # Cast key to object on dask side too
-        df["siteid"] = df["siteid"].astype(object)
-        # Convert monitor_df to dask to ensure consistent merging
-        # and explicitly cast to object to avoid nullable string issues in Pandas 3.0
-        monitor_df_dask = dd.from_pandas(monitor_df, npartitions=1).assign(
-            siteid=lambda x: x.siteid.astype(object)
-        )
-        df = df.merge(monitor_df_dask, on="siteid", how="left")
-    else:
-        df["siteid"] = df["siteid"].astype(object)
-        df = df.merge(monitor_df, on="siteid", how="left")
-
-    return df
+    return add_monitor_metadata(df, airnow=True)

--- a/monetio/readers/aqs.py
+++ b/monetio/readers/aqs.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 from monetio.util import force_object_strings, long_to_wide
 
 from .base import PointReader, register_reader
-from .epa_utils import read_monitor_file
+from .epa_utils import add_monitor_metadata, standardize_epa_units
 from .sat_utils import update_history
 
 logger = logging.getLogger(__name__)
@@ -280,7 +280,7 @@ class AQS:
             df.drop(["datum", "qualifier"], axis=1, inplace=True, errors="ignore")
         voc = "VOC" in url
         df = self.get_species(df, voc=voc)
-        df = self.change_units(df)
+        df = standardize_epa_units(df)
         df = force_object_strings(df)
         return df.drop(columns="date_of_last_change", errors="ignore")
 
@@ -376,40 +376,7 @@ class AQS:
         self, df: Union[pd.DataFrame, "dd.DataFrame"], daily: bool = False, network: str = None
     ) -> Union[pd.DataFrame, "dd.DataFrame"]:
         """Add site metadata and adjust time for daily data."""
-        try:
-            import dask.dataframe as dd
-
-            is_dask = isinstance(df, dd.DataFrame)
-        except ImportError:
-            is_dask = False
-
-        monitor_df = read_monitor_file()
-
-        if network is not None:
-            monitors = monitor_df.loc[monitor_df.isin([network]).any(axis=1)].drop_duplicates(
-                subset=["siteid"]
-            )
-        else:
-            monitors = monitor_df.drop_duplicates(subset=["siteid"])
-
-        # Ensure siteid is object for reliable merging
-        monitors = monitors.copy()
-        monitors["siteid"] = monitors["siteid"].astype(object)
-
-        if is_dask:
-            df["siteid"] = df["siteid"].astype(object)
-            monitors_dask = dd.from_pandas(monitors, npartitions=1)
-            df = df.merge(monitors_dask, on="siteid", how="left")
-        else:
-            df["siteid"] = df["siteid"].astype(object)
-            df = df.merge(monitors, on="siteid", how="left")
-
-        if daily and "gmt_offset" in df.columns:
-            # Adjust time for daily data based on local time and offset
-            if is_dask:
-                df["time"] = df.time_local - dd.to_timedelta(df.gmt_offset, unit="h")
-            else:
-                df["time"] = df.time_local - pd.to_timedelta(df.gmt_offset, unit="h")
+        df = add_monitor_metadata(df, network=network, daily=daily)
 
         if "parameter_name" in df.columns:
             df = df.drop(columns="parameter_name")
@@ -527,40 +494,5 @@ class AQS:
                     warnings.warn(f"Short names not available for these variables:\n{_tbl}")
 
         df["variable"] = df["variable"].fillna(df["parameter_name"])
-
-        return df
-
-    @staticmethod
-    def change_units(
-        df: Union[pd.DataFrame, "dd.DataFrame"],
-    ) -> Union[pd.DataFrame, "dd.DataFrame"]:
-        """Standardize units and adjust observation values accordingly."""
-        # Knots to m/s
-        is_knots = df.units.str.lower() == "knots"
-        df["obs"] = df["obs"].mask(is_knots, df.obs * 0.51444)
-        df["units"] = df["units"].mask(is_knots, "m/s")
-
-        # Fahrenheit to Kelvin
-        is_f = df.units.str.lower() == "degrees fahrenheit"
-        df["obs"] = df["obs"].mask(is_f, (df.obs + 459.67) * 5.0 / 9.0)
-        df["units"] = df["units"].mask(is_f, "k")
-
-        # Others (just rename)
-        unit_map = {
-            "parts per billion carbon": "ppbC",
-            "parts per billion": "ppb",
-            "parts per million": "ppm",
-            "micrograms/cubic meter (25 c)": "ug/m3",
-            "micrograms/cubic meter (lc)": "ug/m3",
-            "degrees centigrade": "c",
-            "percent relative humidity": "%",
-        }
-
-        # Apply mapping to units column
-        df["units_lower"] = df.units.str.lower()
-        for old, new in unit_map.items():
-            df["units"] = df["units"].mask(df.units_lower == old, new)
-
-        df = df.drop(columns="units_lower")
 
         return df

--- a/monetio/readers/epa_utils.py
+++ b/monetio/readers/epa_utils.py
@@ -337,6 +337,7 @@ def add_monitor_metadata(
     airnow: bool = False,
     daily: bool = False,
     left_on: str = "siteid",
+    history_msg: Optional[str] = None,
 ) -> Union[pd.DataFrame, "dd.DataFrame"]:
     """
     Add site metadata from the monitor file (AQS or AirNow).
@@ -353,6 +354,8 @@ def add_monitor_metadata(
         Whether to adjust 'time' for daily data using 'gmt_offset', by default False.
     left_on : str, optional
         The column in `df` to merge on, by default 'siteid'.
+    history_msg : str, optional
+        Optional history message to add to the dataframe attributes, by default None.
 
     Returns
     -------
@@ -405,7 +408,9 @@ def add_monitor_metadata(
         df["time"] = df.time_local - lib.to_timedelta(df.gmt_offset, unit="h")
 
     # Update history
-    df = update_history(df, f"Added station metadata from {'AirNow' if airnow else 'AQS'}.")
+    if history_msg is None:
+        history_msg = f"Added station metadata from {'AirNow' if airnow else 'AQS'}."
+    df = update_history(df, history_msg)
 
     return df
 

--- a/monetio/readers/epa_utils.py
+++ b/monetio/readers/epa_utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional, Union
 import pandas as pd
 
 from ..util import force_object_strings
+from .sat_utils import update_history
 
 if TYPE_CHECKING:
     import dask.dataframe as dd
@@ -325,8 +326,144 @@ def convert_epa_unit(
         df[unit_column] = df[unit_column].mask(mask, ppb)
 
     # Update history
-    from .sat_utils import update_history
-
     df = update_history(df, f"Converted {species} to {to_unit}.")
+
+    return df
+
+
+def add_monitor_metadata(
+    df: Union[pd.DataFrame, "dd.DataFrame"],
+    network: Optional[str] = None,
+    airnow: bool = False,
+    daily: bool = False,
+    left_on: str = "siteid",
+) -> Union[pd.DataFrame, "dd.DataFrame"]:
+    """
+    Add site metadata from the monitor file (AQS or AirNow).
+
+    Parameters
+    ----------
+    df : Union[pd.DataFrame, dd.DataFrame]
+        Input dataframe.
+    network : str, optional
+        Filter by network (e.g., 'IMPROVE'), by default None.
+    airnow : bool, optional
+        Whether to load the AirNow monitor file instead of AQS, by default False.
+    daily : bool, optional
+        Whether to adjust 'time' for daily data using 'gmt_offset', by default False.
+    left_on : str, optional
+        The column in `df` to merge on, by default 'siteid'.
+
+    Returns
+    -------
+    Union[pd.DataFrame, dd.DataFrame]
+        Dataframe with metadata merged.
+
+    Examples
+    --------
+    >>> df = add_monitor_metadata(df, network='IMPROVE', left_on='epaid')
+    """
+    try:
+        import dask.dataframe as dd
+
+        is_dask = isinstance(df, dd.DataFrame)
+        lib = dd if is_dask else pd
+    except ImportError:
+        is_dask = False
+        lib = pd
+
+    monitor_df = read_monitor_file(network=network, airnow=airnow)
+
+    if monitor_df.empty:
+        return df
+
+    # Ensure siteid is unique and object for reliable merging
+    monitor_df = force_object_strings(monitor_df.drop_duplicates(subset=["siteid"]))
+
+    # Prepare keys
+    df = df.assign(**{left_on: df[left_on].astype(object)})
+
+    if is_dask:
+        monitor_wrap = dd.from_pandas(monitor_df, npartitions=1)
+        # Re-force object strings on the Dask-wrapped monitor file
+        # to ensure it doesn't revert to nullable strings during wrapping.
+        monitor_wrap = force_object_strings(monitor_wrap)
+    else:
+        monitor_wrap = monitor_df
+
+    # Merge
+    df = df.merge(monitor_wrap, left_on=left_on, right_on="siteid", how="left")
+
+    # Handle column name conflicts from merge
+    if left_on != "siteid" and "siteid_x" in df.columns:
+        df = df.drop(columns=["siteid_y"], errors="ignore").rename(columns={"siteid_x": "siteid"})
+    elif "siteid_x" in df.columns:
+        df = df.drop(columns=["siteid_y"], errors="ignore").rename(columns={"siteid_x": "siteid"})
+
+    if daily and "gmt_offset" in df.columns and "time_local" in df.columns:
+        # Adjust time for daily data based on local time and offset
+        df["time"] = df.time_local - lib.to_timedelta(df.gmt_offset, unit="h")
+
+    # Update history
+    df = update_history(df, f"Added station metadata from {'AirNow' if airnow else 'AQS'}.")
+
+    return df
+
+
+def standardize_epa_units(
+    df: Union[pd.DataFrame, "dd.DataFrame"],
+) -> Union[pd.DataFrame, "dd.DataFrame"]:
+    """
+    Standardize EPA units and adjust observation values accordingly.
+
+    Converts:
+    - Knots to m/s
+    - degrees Fahrenheit to K
+    - Normalizes several common unit names (e.g., 'parts per billion' to 'ppb')
+
+    Parameters
+    ----------
+    df : Union[pd.DataFrame, dd.DataFrame]
+        Input dataframe.
+
+    Returns
+    -------
+    Union[pd.DataFrame, dd.DataFrame]
+        Dataframe with standardized units and values.
+
+    Examples
+    --------
+    >>> df = standardize_epa_units(df)
+    """
+    # Knots to m/s
+    is_knots = df.units.str.lower() == "knots"
+    df["obs"] = df["obs"].mask(is_knots, df.obs * 0.51444)
+    df["units"] = df["units"].mask(is_knots, "m/s")
+
+    # Fahrenheit to Kelvin
+    is_f = df.units.str.lower() == "degrees fahrenheit"
+    df["obs"] = df["obs"].mask(is_f, (df.obs + 459.67) * 5.0 / 9.0)
+    df["units"] = df["units"].mask(is_f, "k")
+
+    # Others (just rename)
+    unit_map = {
+        "parts per billion carbon": "ppbC",
+        "parts per billion": "ppb",
+        "parts per million": "ppm",
+        "micrograms/cubic meter (25 c)": "ug/m3",
+        "micrograms/cubic meter (lc)": "ug/m3",
+        "degrees centigrade": "c",
+        "percent relative humidity": "%",
+    }
+
+    # Apply mapping to units column
+    df["units_lower"] = df.units.str.lower()
+    for old, new in unit_map.items():
+        df["units"] = df["units"].mask(df.units_lower == old, new)
+
+    df = df.drop(columns="units_lower")
+
+    # Update history
+    df = update_history(df, "Standardized units and adjusted observation values.")
 
     return df

--- a/monetio/readers/improve.py
+++ b/monetio/readers/improve.py
@@ -9,7 +9,7 @@ import xarray as xr
 from ..util import force_object_strings
 from .base import PointReader, register_reader
 from .drivers import FileUtility
-from .epa_utils import read_monitor_file
+from .epa_utils import add_monitor_metadata
 from .sat_utils import update_history
 
 try:
@@ -125,34 +125,13 @@ class IMPROVEReader(PointReader):
         --------
         >>> df = reader.add_metadata(df)
         """
-        monitor_df = read_monitor_file(network="IMPROVE")
+        df = add_monitor_metadata(df, network="IMPROVE", left_on="epaid")
 
-        # Ensure siteid is object for reliable merging
-        monitor_df = monitor_df.copy().drop_duplicates(subset=["siteid"])
-        monitor_df = force_object_strings(monitor_df)
-
-        # Backend-agnostic site ID cast
-        df["epaid"] = df["epaid"].astype(object)
-
-        # Identify backend and wrap monitor_df if needed
-        if hasattr(df, "npartitions"):
-            # Dask detected
-            import dask.dataframe as dd_local
-
-            monitor_wrap = dd_local.from_pandas(monitor_df, npartitions=1)
-        else:
-            monitor_wrap = monitor_df
-
-        # Merge
-        df = df.merge(monitor_wrap, left_on="epaid", right_on="siteid", how="left")
-
-        # Handle column name conflicts from merge
-        if "siteid_x" in df.columns:
-            df = df.drop(columns=["siteid_y", "state_name_y"], errors="ignore")
-            df = df.rename(columns={"siteid_x": "siteid", "state_name_x": "state_name"})
-
-        # Update history if possible
-        df = update_history(df, "Merged with IMPROVE station metadata.")
+        # Handle IMPROVE-specific column name cleanup
+        if "state_name_y" in df.columns:
+            df = df.drop(columns=["state_name_y"], errors="ignore").rename(
+                columns={"state_name_x": "state_name"}
+            )
 
         return df
 

--- a/monetio/readers/improve.py
+++ b/monetio/readers/improve.py
@@ -125,7 +125,12 @@ class IMPROVEReader(PointReader):
         --------
         >>> df = reader.add_metadata(df)
         """
-        df = add_monitor_metadata(df, network="IMPROVE", left_on="epaid")
+        df = add_monitor_metadata(
+            df,
+            network="IMPROVE",
+            left_on="epaid",
+            history_msg="Merged with IMPROVE station metadata.",
+        )
 
         # Handle IMPROVE-specific column name cleanup
         if "state_name_y" in df.columns:

--- a/tests/test_aero_airnow.py
+++ b/tests/test_aero_airnow.py
@@ -41,9 +41,9 @@ def test_airnow_eager_vs_lazy_local(mock_airnow_file, monkeypatch):
             }
         )
 
-    import monetio.readers.airnow as airnow
+    import monetio.readers.epa_utils as epa_utils
 
-    monkeypatch.setattr(airnow, "read_monitor_file", mock_read_monitor)
+    monkeypatch.setattr(epa_utils, "read_monitor_file", mock_read_monitor)
     reader = AirNowReader()
     ds_eager = reader.open_dataset(
         files=mock_airnow_file, as_xarray=True, lazy=False, wide_fmt=True, bad_utcoffset="fix"

--- a/tests/test_aero_more_readers.py
+++ b/tests/test_aero_more_readers.py
@@ -22,7 +22,7 @@ def mock_improve_file(tmp_path):
 def test_improve_reader_eager(mock_improve_file):
     reader = IMPROVEReader()
     # Mock monitor file read
-    with patch("monetio.readers.improve.read_monitor_file") as mock_mon:
+    with patch("monetio.readers.epa_utils.read_monitor_file") as mock_mon:
         mock_mon.return_value = pd.DataFrame(
             {"siteid": ["123456789"], "latitude": [39.0], "longitude": [-76.5]}
         )
@@ -36,7 +36,7 @@ def test_improve_reader_eager(mock_improve_file):
 def test_improve_reader_lazy(mock_improve_file):
     pytest.importorskip("dask")
     reader = IMPROVEReader()
-    with patch("monetio.readers.improve.read_monitor_file") as mock_mon:
+    with patch("monetio.readers.epa_utils.read_monitor_file") as mock_mon:
         mock_mon.return_value = pd.DataFrame(
             {"siteid": ["123456789"], "latitude": [39.0], "longitude": [-76.5]}
         )


### PR DESCRIPTION
This PR centralizes duplicated logic for station metadata merging and unit standardization across AQS, IMPROVE, and AirNow readers into `monetio/readers/epa_utils.py`. The refactoring adheres to the Aero Protocol, ensuring that these operations are backend-agnostic (working seamlessly with both Pandas and Dask DataFrames) and maintain data provenance. This change reduces technical debt, eliminates "Backend Locking" code smells, and improves the overall maintainability of the EPA-related data pipelines.

---
*PR created automatically by Jules for task [10682834326585523800](https://jules.google.com/task/10682834326585523800) started by @bbakernoaa*