### PR TITLE
Add SURFRAD and SOLRAD observation readers

### DIFF
--- a/monetio/__init__.py
+++ b/monetio/__init__.py
@@ -108,6 +108,8 @@ _READER_MODULES = {
     "openaq": ".readers.openaq",
     "pams": ".readers.pams",
     "ndbc": ".readers.ndbc",
+    "surfrad": ".readers.surfrad",
+    "solrad": ".readers.solrad",
     # Profile
     "icartt": ".readers.icartt",
     "tolnet": ".readers.tolnet",

--- a/monetio/obs/solrad.py
+++ b/monetio/obs/solrad.py
@@ -1,0 +1,21 @@
+"""
+SOLRAD Reader Redirection
+"""
+
+from ..readers.solrad import SOLRADReader
+
+
+def add_data(
+    dates,
+    *,
+    sites=None,
+    as_xarray=True,
+    **kwargs,
+):
+    """Retrieve and load SOLRAD data."""
+    return SOLRADReader().open_dataset(
+        dates=dates,
+        sites=sites,
+        as_xarray=as_xarray,
+        **kwargs,
+    )

--- a/monetio/obs/surfrad.py
+++ b/monetio/obs/surfrad.py
@@ -1,0 +1,21 @@
+"""
+SURFRAD Reader Redirection
+"""
+
+from ..readers.surfrad import SURFRADReader
+
+
+def add_data(
+    dates,
+    *,
+    sites=None,
+    as_xarray=True,
+    **kwargs,
+):
+    """Retrieve and load SURFRAD data."""
+    return SURFRADReader().open_dataset(
+        dates=dates,
+        sites=sites,
+        as_xarray=as_xarray,
+        **kwargs,
+    )

--- a/monetio/readers/solrad.py
+++ b/monetio/readers/solrad.py
@@ -1,0 +1,288 @@
+"""SOLRAD Reader"""
+
+import io
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from ..util import force_object_strings
+from .base import PointReader, register_reader
+from .drivers import FileUtility
+from .sat_utils import update_history
+
+if TYPE_CHECKING:
+    import dask.dataframe as dd
+
+# Base headers for SOLRAD
+BASE_HEADERS = (
+    "year",
+    "jday",
+    "month",
+    "day",
+    "hour",
+    "minute",
+    "dt",
+    "zen",
+    "ghi",
+    "ghi_flag",
+    "dni",
+    "dni_flag",
+    "dhi",
+    "dhi_flag",
+    "uvb",
+    "uvb_flag",
+    "uvb_temp",
+    "uvb_temp_flag",
+)
+
+# Standard headers for remaining columns
+STD_HEADERS = ("std_ghi", "std_dni", "std_dhi", "std_uvb")
+HEADERS = BASE_HEADERS + STD_HEADERS
+
+# Headers for Madison, WI site (includes DPIR)
+DPIR_HEADERS = ("dpir", "dpir_flag", "dpirc", "dpirc_flag", "dpird", "dpird_flag")
+MADISON_HEADERS = BASE_HEADERS + DPIR_HEADERS + STD_HEADERS + ("std_dpir", "std_dpirc", "std_dpird")
+
+# Fixed-width columns (base widths from README_SOLRAD.txt)
+# year(4), jday(3), month(2), day(2), hour(2), minute(2), dt(6), zen(6)
+# then 5 pairs of (value(7), flag(1)) for ghi, dni, dhi, uvb, uvb_temp
+# then 4 values of 9 chars for std_ghi, std_dni, std_dhi, std_uvb
+WIDTHS = [4, 3, 2, 2, 2, 2, 6, 6] + 5 * [7, 1] + 4 * [9]
+# Madison has 8 pairs of (value, flag) because of DPIR
+MADISON_WIDTHS = [4, 3, 2, 2, 2, 2, 6, 6] + 8 * [7, 1] + 7 * [9]
+
+
+# In the files, there is one space between columns.
+# To use read_fwf, we can either provide widths that include the space,
+# or better, use colspecs.
+def get_colspecs(widths):
+    colspecs = []
+    start = 0
+    for w in widths:
+        # Each field of width w is followed by 1 space, except possibly the last
+        # But actually, the total width of the field including the trailing space is w+1.
+        colspecs.append((start, start + w))
+        start += w + 1
+    return colspecs
+
+
+COLSPECS = get_colspecs(WIDTHS)
+MADISON_COLSPECS = get_colspecs(MADISON_WIDTHS)
+
+# Variable mapping for SOLRAD
+VARIABLE_MAP = {
+    "zen": "solar_zenith",
+    # ghi, dni, dhi are already standard-ish
+}
+
+
+def read_solrad(filename: str, **kwargs: dict) -> pd.DataFrame:
+    """
+    Read a single SOLRAD file.
+
+    Parameters
+    ----------
+    filename : str
+        The path or URL to the SOLRAD file.
+    **kwargs : dict
+        Additional arguments passed to pd.read_fwf.
+
+    Returns
+    -------
+    pd.DataFrame
+        The loaded data.
+    """
+    if "msn" in filename.lower():
+        names = MADISON_HEADERS
+        colspecs = MADISON_COLSPECS
+    else:
+        names = HEADERS
+        colspecs = COLSPECS
+
+    # Use FileUtility to handle remote files
+    fs = FileUtility.get_fs(filename)
+    with fs.open(filename, "r") as f:
+        content = f.read()
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="ignore")
+
+        lines = content.splitlines()
+        if len(lines) < 3:
+            return pd.DataFrame()
+
+        station_name = lines[0].strip()
+        metadata_line = lines[1].split()
+
+        latitude = float(metadata_line[0])
+        longitude = float(metadata_line[1])
+        elevation = float(metadata_line[2])
+        # tz_offset = int(metadata_line[3])
+
+        # Data starts from line 2
+        data_content = "\n".join(lines[2:])
+        df = pd.read_fwf(
+            io.StringIO(data_content),
+            colspecs=colspecs,
+            header=None,
+            names=names,
+            na_values=-9999.9,
+            **kwargs,
+        )
+
+    # Add metadata
+    df["latitude"] = latitude
+    df["longitude"] = longitude
+    df["elevation"] = elevation
+    df["siteid"] = station_name
+
+    # Create time column
+    # Ensure columns are integer and then format to string with zfill
+    # We use a custom converter to handle potential issues with read_fwf and NaN in time columns
+    def to_str(series, n):
+        # Handle cases where column might be floating point because of NaNs, or already string
+        # We ensure they are numeric first to avoid '.0' in string conversion
+        s = pd.to_numeric(series, errors="coerce").fillna(0).astype(int).astype(str)
+        return s.str.zfill(n)
+
+    df["time"] = pd.to_datetime(
+        to_str(df["year"], 4)
+        + to_str(df["month"], 2)
+        + to_str(df["day"], 2)
+        + to_str(df["hour"], 2)
+        + to_str(df["minute"], 2),
+        format="%Y%m%d%H%M",
+        errors="coerce",
+    )
+
+    return df
+
+
+@register_reader("solrad")
+class SOLRADReader(PointReader):
+    """
+    Reader for NOAA SOLRAD network data.
+    """
+
+    def open_dataset(
+        self,
+        files: Optional[Union[str, List[str]]] = None,
+        dates: Optional[Union[datetime, List[datetime], pd.DatetimeIndex]] = None,
+        sites: Optional[List[str]] = None,
+        as_xarray: bool = True,
+        lazy: bool = False,
+        **kwargs,
+    ) -> Union[xr.Dataset, pd.DataFrame]:
+        """
+        Open SOLRAD dataset.
+
+        Parameters
+        ----------
+        files : Union[str, List[str]], optional
+            File paths or URLs. If None, uses `dates` and `sites` to discover files.
+        dates : Union[datetime, List[datetime], pd.DatetimeIndex], optional
+            Dates to retrieve if `files` is None.
+        sites : List[str], optional
+            Site abbreviations (e.g. ['abq', 'bis', 'hnx', 'msn', 'slc', 'sea', 'ste']).
+        as_xarray : bool, optional
+            If True, returns an xarray.Dataset, by default True.
+        lazy : bool, optional
+            If True, returns a dask-backed object, by default False.
+        **kwargs : dict
+            Additional arguments passed to the reader and driver.
+
+        Returns
+        -------
+        Union[xr.Dataset, pd.DataFrame]
+            The loaded dataset.
+        """
+        if files is None:
+            if dates is None or sites is None:
+                raise ValueError("Either 'files' or both 'dates' and 'sites' must be provided.")
+            files = self.build_urls(dates, sites)
+
+        # Separate driver kwargs from to_xarray/postprocess kwargs
+        driver_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in ["expand2d", "wide_fmt", "pivot", "as_xarray", "lazy"]
+        }
+
+        # We use read_solrad as the custom read_method
+        df = self.driver.open(files, read_method=read_solrad, lazy=lazy, **driver_kwargs)
+
+        # Post-processing: Harmonize column names
+        df = self._postprocess(df)
+
+        # Consistently force object strings
+        df = force_object_strings(df)
+
+        if as_xarray:
+            ds = self.to_xarray(df, **kwargs)
+            # Update history for provenance
+            ds = update_history(ds, "Harmonized SOLRAD dataset.")
+            return ds
+
+        return df
+
+    def _postprocess(
+        self, df: Union[pd.DataFrame, "dd.DataFrame"]
+    ) -> Union[pd.DataFrame, "dd.DataFrame"]:
+        """
+        Harmonize column names.
+
+        Parameters
+        ----------
+        df : Union[pd.DataFrame, dd.DataFrame]
+            Input dataframe.
+
+        Returns
+        -------
+        Union[pd.DataFrame, dd.DataFrame]
+            Post-processed dataframe.
+        """
+        # Rename according to VARIABLE_MAP
+        df = df.rename(columns=VARIABLE_MAP)
+
+        # Update history for provenance
+        df = update_history(df, "Applied variable name mapping for SOLRAD.")
+
+        return df
+
+    def build_urls(
+        self,
+        dates: Union[datetime, List[datetime], pd.DatetimeIndex],
+        sites: List[str],
+    ) -> List[str]:
+        """
+        Discover available URLs for the given dates and sites.
+
+        Parameters
+        ----------
+        dates : Union[datetime, List[datetime], pd.DatetimeIndex]
+            Dates to retrieve.
+        sites : List[str]
+            Site abbreviations.
+
+        Returns
+        -------
+        List[str]
+            List of URLs.
+        """
+        baseurl = "https://gml.noaa.gov/aftp/data/radiation/solrad/"
+
+        urls = []
+        dates = pd.DatetimeIndex(np.atleast_1d(dates))
+
+        for date in dates:
+            for site in sites:
+                year = date.year
+                # Format: site/year/siteyyjday.dat
+                # e.g. abq/2024/abq24001.dat
+                fname = f"{site.lower()}{date.strftime('%y%j')}.dat"
+                url = f"{baseurl}{site.lower()}/{year}/{fname}"
+                urls.append(url)
+
+        return urls

--- a/monetio/readers/surfrad.py
+++ b/monetio/readers/surfrad.py
@@ -1,0 +1,289 @@
+"""SURFRAD Reader"""
+
+import io
+from datetime import datetime
+from typing import TYPE_CHECKING, List, Optional, Union
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from ..util import force_object_strings
+from .base import PointReader, register_reader
+from .drivers import FileUtility
+from .sat_utils import update_history
+
+if TYPE_CHECKING:
+    import dask.dataframe as dd
+
+SURFRAD_COLUMNS = [
+    "year",
+    "jday",
+    "month",
+    "day",
+    "hour",
+    "minute",
+    "dt",
+    "zen",
+    "dw_solar",
+    "dw_solar_flag",
+    "uw_solar",
+    "uw_solar_flag",
+    "direct_n",
+    "direct_n_flag",
+    "diffuse",
+    "diffuse_flag",
+    "dw_ir",
+    "dw_ir_flag",
+    "dw_casetemp",
+    "dw_casetemp_flag",
+    "dw_dometemp",
+    "dw_dometemp_flag",
+    "uw_ir",
+    "uw_ir_flag",
+    "uw_casetemp",
+    "uw_casetemp_flag",
+    "uw_dometemp",
+    "uw_dometemp_flag",
+    "uvb",
+    "uvb_flag",
+    "par",
+    "par_flag",
+    "netsolar",
+    "netsolar_flag",
+    "netir",
+    "netir_flag",
+    "totalnet",
+    "totalnet_flag",
+    "temp",
+    "temp_flag",
+    "rh",
+    "rh_flag",
+    "windspd",
+    "windspd_flag",
+    "winddir",
+    "winddir_flag",
+    "pressure",
+    "pressure_flag",
+]
+
+# Dictionary mapping surfrad variables to standard names
+VARIABLE_MAP = {
+    "temp": "air_temperature",
+    "rh": "relative_humidity",
+    "windspd": "wind_speed",
+    "winddir": "wind_direction",
+    "pressure": "surface_pressure",
+    "dw_solar": "ghi",
+    "direct_n": "dni",
+    "diffuse": "dhi",
+}
+
+
+def read_surfrad(filename: str, **kwargs: dict) -> pd.DataFrame:
+    """
+    Read a single SURFRAD file.
+
+    Parameters
+    ----------
+    filename : str
+        The path or URL to the SURFRAD file.
+    **kwargs : dict
+        Additional arguments passed to pd.read_csv.
+
+    Returns
+    -------
+    pd.DataFrame
+        The loaded data.
+    """
+    # Use FileUtility to handle remote files
+    fs = FileUtility.get_fs(filename)
+    with fs.open(filename, "r") as f:
+        # Read first two lines for metadata
+        # Some files might have encoding issues, so we read as bytes and decode
+        content = f.read()
+        if isinstance(content, bytes):
+            content = content.decode("utf-8", errors="ignore")
+
+        lines = content.splitlines()
+        if len(lines) < 3:
+            return pd.DataFrame()
+
+        station_name = lines[0].strip()
+        metadata_line = lines[1].split()
+
+        latitude = float(metadata_line[0])
+        longitude = float(metadata_line[1])
+        elevation = float(metadata_line[2])
+        # version = int(metadata_line[-1]) # not used currently
+
+        # Data starts from line 2
+        data_content = "\n".join(lines[2:])
+        df = pd.read_csv(
+            io.StringIO(data_content),
+            sep=r"\s+",
+            names=SURFRAD_COLUMNS,
+            header=None,
+            na_values=[-9999.9, -999.9, -99.9],
+            **kwargs,
+        )
+
+    # Add metadata as columns (will be coordinates in xarray)
+    df["latitude"] = latitude
+    df["longitude"] = longitude
+    df["elevation"] = elevation
+    df["siteid"] = station_name
+
+    # Create time column
+    # year, jday, hour, minute
+    # jday is 1-indexed
+    df["time"] = pd.to_datetime(
+        df["year"].astype(str)
+        + df["jday"].astype(str).str.zfill(3)
+        + df["hour"].astype(str).str.zfill(2)
+        + df["minute"].astype(str).str.zfill(2),
+        format="%Y%j%H%M",
+        errors="coerce",
+    )
+
+    return df
+
+
+@register_reader("surfrad")
+class SURFRADReader(PointReader):
+    """
+    Reader for Surface Radiation Budget Network (SURFRAD) data.
+    """
+
+    def open_dataset(
+        self,
+        files: Optional[Union[str, List[str]]] = None,
+        dates: Optional[Union[datetime, List[datetime], pd.DatetimeIndex]] = None,
+        sites: Optional[List[str]] = None,
+        as_xarray: bool = True,
+        lazy: bool = False,
+        **kwargs,
+    ) -> Union[xr.Dataset, pd.DataFrame]:
+        """
+        Open SURFRAD dataset.
+
+        Parameters
+        ----------
+        files : Union[str, List[str]], optional
+            File paths or URLs. If None, uses `dates` and `sites` to discover files.
+        dates : Union[datetime, List[datetime], pd.DatetimeIndex], optional
+            Dates to retrieve if `files` is None.
+        sites : List[str], optional
+            Site abbreviations (e.g. ['tbl', 'bon', 'fpk', 'gwn', 'psu', 'sxf', 'dra']).
+        as_xarray : bool, optional
+            If True, returns an xarray.Dataset, by default True.
+        lazy : bool, optional
+            If True, returns a dask-backed object, by default False.
+        **kwargs : dict
+            Additional arguments passed to the reader and driver.
+
+        Returns
+        -------
+        Union[xr.Dataset, pd.DataFrame]
+            The loaded dataset.
+        """
+        if files is None:
+            if dates is None or sites is None:
+                raise ValueError("Either 'files' or both 'dates' and 'sites' must be provided.")
+            files = self.build_urls(dates, sites)
+
+        # Separate driver kwargs from to_xarray/postprocess kwargs
+        driver_kwargs = {
+            k: v
+            for k, v in kwargs.items()
+            if k not in ["expand2d", "wide_fmt", "pivot", "as_xarray", "lazy"]
+        }
+
+        # We use read_surfrad as the custom read_method
+        df = self.driver.open(files, read_method=read_surfrad, lazy=lazy, **driver_kwargs)
+
+        # Post-processing: Harmonize column names
+        df = self._postprocess(df)
+
+        # Consistently force object strings
+        df = force_object_strings(df)
+
+        if as_xarray:
+            ds = self.to_xarray(df, **kwargs)
+            # Update history for provenance
+            ds = update_history(ds, "Harmonized SURFRAD dataset.")
+            return ds
+
+        return df
+
+    def _postprocess(
+        self, df: Union[pd.DataFrame, "dd.DataFrame"]
+    ) -> Union[pd.DataFrame, "dd.DataFrame"]:
+        """
+        Harmonize column names.
+
+        Parameters
+        ----------
+        df : Union[pd.DataFrame, dd.DataFrame]
+            Input dataframe.
+
+        Returns
+        -------
+        Union[pd.DataFrame, dd.DataFrame]
+            Post-processed dataframe.
+        """
+        # Rename according to VARIABLE_MAP
+        df = df.rename(columns=VARIABLE_MAP)
+
+        # Update history for provenance
+        df = update_history(df, "Applied variable name mapping for SURFRAD.")
+
+        return df
+
+    def build_urls(
+        self,
+        dates: Union[datetime, List[datetime], pd.DatetimeIndex],
+        sites: List[str],
+    ) -> List[str]:
+        """
+        Discover available URLs for the given dates and sites.
+
+        Parameters
+        ----------
+        dates : Union[datetime, List[datetime], pd.DatetimeIndex]
+            Dates to retrieve.
+        sites : List[str]
+            Site abbreviations.
+
+        Returns
+        -------
+        List[str]
+            List of URLs.
+        """
+        baseurl = "https://gml.noaa.gov/aftp/data/radiation/surfrad/"
+
+        # Site mapping from abbreviation to directory name
+        site_map = {
+            "tbl": "Table_Mountain_CO",
+            "bon": "Bondville_IL",
+            "fpk": "Fort_Peck_MT",
+            "gwn": "Goodwin_Creek_MS",
+            "psu": "Penn_State_PA",
+            "sxf": "Sioux_Falls_SD",
+            "dra": "Desert_Rock_NV",
+        }
+
+        urls = []
+        dates = pd.DatetimeIndex(np.atleast_1d(dates))
+
+        for date in dates:
+            for site in sites:
+                site_dir = site_map.get(site.lower(), site)
+                year = date.year
+                # Format: site_dir/year/site_yyjday.dat
+                # e.g. Bondville_IL/2024/bon24001.dat
+                fname = f"{site.lower()}{date.strftime('%y%j')}.dat"
+                url = f"{baseurl}{site_dir}/{year}/{fname}"
+                urls.append(url)
+
+        return urls

--- a/tests/test_aero_solrad.py
+++ b/tests/test_aero_solrad.py
@@ -1,0 +1,123 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from monetio.readers.solrad import SOLRADReader
+
+
+def test_solrad_reader_basic(tmp_path):
+    # Create a mock SOLRAD file (non-Madison)
+    # WIDTHS = [4, 3, 2, 2, 2, 2, 6, 6] + 5 * [7, 1] + 4 * [9]
+    def fmt_solrad(
+        y,
+        jd,
+        m,
+        d,
+        h,
+        mi,
+        dt,
+        zen,
+        ghi,
+        ghf,
+        dni,
+        dnf,
+        dhi,
+        dhf,
+        uvb,
+        uvf,
+        uvbt,
+        uvbtf,
+        sghi,
+        sdni,
+        sdhi,
+        suvb,
+    ):
+        return (
+            f"{y:4d} {jd:3d} {m:2d} {d:2d} {h:2d} {mi:2d} {dt:6.3f} {zen:6.2f} "
+            f"{ghi:7.1f} {ghf:1d} {dni:7.1f} {dnf:1d} {dhi:7.1f} {dhf:1d} {uvb:7.1f} {uvf:1d} {uvbt:7.1f} {uvbtf:1d} "
+            f"{sghi:9.1f} {sdni:9.1f} {sdhi:9.1f} {suvb:9.1f}"
+        )
+
+    l1 = fmt_solrad(
+        2024,
+        1,
+        1,
+        1,
+        0,
+        0,
+        0.0,
+        0.0,
+        -9999.9,
+        0,
+        -9999.9,
+        0,
+        -9999.9,
+        0,
+        -9999.9,
+        0,
+        -9999.9,
+        0,
+        -9999.9,
+        -9999.9,
+        -9999.9,
+        -9999.9,
+    )
+    l2 = fmt_solrad(
+        2024,
+        1,
+        1,
+        1,
+        0,
+        1,
+        0.017,
+        0.0,
+        100.0,
+        0,
+        200.0,
+        0,
+        300.0,
+        0,
+        400.0,
+        0,
+        500.0,
+        0,
+        10.0,
+        20.0,
+        30.0,
+        40.0,
+    )
+
+    mock_content = f"Albuquerque, NM\n35.03796 -106.62211 1617 7\n{l1}\n{l2}\n"
+
+    f = tmp_path / "abq24001.dat"
+    f.write_text(mock_content)
+
+    reader = SOLRADReader()
+
+    # Test Eager
+    df = reader.open_dataset(files=str(f), as_xarray=False)
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    assert df["siteid"].iloc[0] == "Albuquerque, NM"
+    assert df["latitude"].iloc[0] == 35.03796
+    assert df["time"].iloc[0] == pd.Timestamp("2024-01-01 00:00:00")
+
+    # Check NaN
+    assert np.isnan(df["ghi"].iloc[0])
+    assert df["ghi"].iloc[1] == 100.0
+
+    # Test Lazy
+    ds = reader.open_dataset(files=str(f), as_xarray=True, lazy=True)
+    assert isinstance(ds, xr.Dataset)
+    assert "ghi" in ds.data_vars
+    assert ds.sizes["time"] == 2
+
+
+def test_solrad_build_urls():
+    reader = SOLRADReader()
+    dates = pd.to_datetime(["2024-01-01"])
+    sites = ["abq"]
+    urls = reader.build_urls(dates, sites)
+
+    assert len(urls) == 1
+    assert "https://gml.noaa.gov/aftp/data/radiation/solrad/abq/2024/abq24001.dat" in urls

--- a/tests/test_aero_surfrad.py
+++ b/tests/test_aero_surfrad.py
@@ -1,0 +1,67 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from monetio.readers.surfrad import SURFRADReader
+
+
+def test_surfrad_reader_basic(tmp_path):
+    # Create a mock SURFRAD file
+    mock_content = """Bondville, IL
+40.05192 -88.37309 213 1
+2024 1 1 1 0 0 0.000 0.00 -9999.9 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 0.00 0 25.0 0 50.0 0 5.0 0 180.0 0 1013.2 0
+2024 1 1 1 0 1 0.017 0.00 100.0 0 10.0 0 50.0 0 20.0 0 300.0 0 290.0 0 290.0 0 310.0 0 295.0 0 295.0 0 0.50 0 10.0 0 90.0 0 -10.0 0 80.0 0 25.1 0 50.1 0 5.1 0 181.0 0 1013.3 0
+"""
+    f = tmp_path / "bon24001.dat"
+    f.write_text(mock_content)
+
+    reader = SURFRADReader()
+
+    # Test Eager
+    df = reader.open_dataset(files=str(f), as_xarray=False)
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 2
+    assert df["air_temperature"].iloc[0] == 25.0
+    assert df["siteid"].iloc[0] == "Bondville, IL"
+    assert df["latitude"].iloc[0] == 40.05192
+    assert df["longitude"].iloc[0] == -88.37309
+    assert df["elevation"].iloc[0] == 213.0
+    assert df["time"].iloc[0] == pd.Timestamp("2024-01-01 00:00:00")
+    assert df["time"].iloc[1] == pd.Timestamp("2024-01-01 00:01:00")
+    # Check NaN handling
+    assert np.isnan(df["ghi"].iloc[0])
+    assert df["ghi"].iloc[1] == 100.0
+
+    # Test Lazy (if dask is available, PointReader handles it via driver)
+    # By default it expands to 2D (time, node)
+    ds = reader.open_dataset(files=str(f), as_xarray=True, lazy=True)
+    assert isinstance(ds, xr.Dataset)
+    assert "air_temperature" in ds.data_vars
+    assert "time" in ds.coords
+    # 1 site -> node size 1; 2 time steps -> time size 2
+    assert ds.sizes["node"] == 1
+    assert ds.sizes["time"] == 2
+
+    # Test without 2D expansion
+    ds = reader.open_dataset(files=str(f), as_xarray=True, expand2d=False)
+    assert ds.sizes["node"] == 2
+    assert "time" in ds.coords
+
+    # Verify coordinates
+    assert ds.latitude.attrs["units"] == "degrees_north"
+    assert ds.longitude.attrs["units"] == "degrees_east"
+    assert ds.elevation.attrs["units"] == "m"
+
+
+def test_surfrad_build_urls():
+    reader = SURFRADReader()
+    dates = pd.to_datetime(["2024-01-01"])
+    sites = ["bon", "tbl"]
+    urls = reader.build_urls(dates, sites)
+
+    assert len(urls) == 2
+    assert "https://gml.noaa.gov/aftp/data/radiation/surfrad/Bondville_IL/2024/bon24001.dat" in urls
+    assert (
+        "https://gml.noaa.gov/aftp/data/radiation/surfrad/Table_Mountain_CO/2024/tbl24001.dat"
+        in urls
+    )


### PR DESCRIPTION
This PR adds support for the SURFRAD and SOLRAD radiation observation networks to `monetio`. These networks provide high-quality surface radiation and meteorological measurements essential for weather and land modeling.

Key features:
- **SURFRAD Reader**: Parses 48-column ASCII data from the SURFRAD network.
- **SOLRAD Reader**: Parses fixed-width ASCII data from the SOLRAD network, with automatic detection of the Madison, WI site format.
- **Aero Protocol Compliance**: Both readers support backend-agnostic loading (Eager/Lazy) and track data provenance via `update_history`.
- **Standardization**: Variables like `ghi`, `dni`, `dhi`, `air_temperature`, `relative_humidity`, and `wind_speed` are harmonized across readers.
- **Automated Retrieval**: Includes `build_urls` logic to discover and download data files from NOAA GML's archive based on dates and site IDs.
- **Testing**: New tests verify parsing, coordinate assignment, and backend consistency using mock data.

---
*PR created automatically by Jules for task [2106468097605916705](https://jules.google.com/task/2106468097605916705) started by @bbakernoaa*