### PR TITLE
Add MERRA-2 reader with .netrc support and hybrid pressure calculation

### DIFF
--- a/monetio/__init__.py
+++ b/monetio/__init__.py
@@ -128,6 +128,7 @@ _READER_MODULES = {
     "mopitt": ".readers.mopitt",
     "tempo": ".readers.tempo",
     "tropomi": ".readers.tropomi",
+    "merra2": ".readers.merra2",
     "nesdis_viirs_jrr": ".readers.nesdis_viirs_jrr",
     "viirs_jrr": ".readers.nesdis_viirs_jrr",
 }

--- a/monetio/readers/merra2.py
+++ b/monetio/readers/merra2.py
@@ -1,0 +1,160 @@
+"""MERRA-2 Reader"""
+
+from typing import List, Optional, Union
+
+import xarray as xr
+
+from .base import GriddedReader, register_reader
+from .nasa_utils import setup_netrc
+from .sat_utils import standardize_satellite_coords, update_history
+
+
+@register_reader("merra2")
+class MERRA2Reader(GriddedReader):
+    """
+    Reader for MERRA-2 (Modern-Era Retrospective analysis for Research and Applications, Version 2) data.
+    """
+
+    def open_dataset(
+        self,
+        files: Union[str, List[str]],
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        **kwargs,
+    ) -> xr.Dataset:
+        """
+        Reads MERRA-2 data.
+
+        Parameters
+        ----------
+        files : Union[str, List[str]]
+            File path(s) or URL(s).
+        username : str, optional
+            NASA Earthdata username. If provided, will setup .netrc.
+        password : str, optional
+            NASA Earthdata password. If provided, will setup .netrc.
+        **kwargs : dict
+            Additional arguments passed to XarrayDriver.open.
+
+        Returns
+        -------
+        xr.Dataset
+            The MERRA-2 dataset.
+        """
+        if username and password:
+            setup_netrc(username, password)
+
+        if "preprocess" not in kwargs:
+            kwargs["preprocess"] = merra2_preprocess
+
+        ds = super().open_dataset(files, **kwargs)
+
+        # Update history
+        ds = update_history(ds, "Read MERRA-2 data.")
+
+        return ds
+
+
+def merra2_preprocess(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Preprocess MERRA-2 dataset: standardize coordinates and metadata.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input dataset.
+
+    Returns
+    -------
+    xr.Dataset
+        Processed dataset.
+    """
+    # 1. Pre-standardize coordinates to avoid losing them during dimension rename
+    # if they share the same name.
+    if "lat" in ds.coords and "latitude" not in ds.coords:
+        ds = ds.assign_coords(latitude=ds.lat)
+    if "lon" in ds.coords and "longitude" not in ds.coords:
+        ds = ds.assign_coords(longitude=ds.lon)
+
+    # 2. Standardize dimensions and coordinates
+    # MERRA-2 typically uses 'lat', 'lon', 'time', 'lev'.
+    ds = standardize_satellite_coords(
+        ds,
+        lat_name="latitude",
+        lon_name="longitude",
+        y_dim=["lat", "nlat", "y"],
+        x_dim=["lon", "nlon", "x"],
+        z_dim=["lev", "level", "layer"],
+    )
+
+    # 3. Expand 1D coords to 2D for UGRID/CF compliance in MONETIO if needed
+    if "latitude" in ds.coords and ds["latitude"].ndim == 1:
+        if "longitude" in ds.coords and ds["longitude"].ndim == 1:
+            # Use lazy broadcasting
+            lons, lats = xr.broadcast(ds.longitude, ds.latitude)
+            # Ensure (y, x) order which is standard for gridded data in MONETIO
+            if "y" in lons.dims and "x" in lons.dims:
+                lons = lons.transpose("y", "x")
+                lats = lats.transpose("y", "x")
+            # Re-assign as 2D coordinates
+            ds = ds.assign_coords(longitude=lons, latitude=lats)
+
+    # 3. Variable renaming to standard names if they exist
+    mapping = {
+        "PS": "surface_pressure",
+        "T": "temperature",
+        "QV": "specific_humidity",
+        "U": "u_wind",
+        "V": "v_wind",
+    }
+    rename_dict = {
+        old: new for old, new in mapping.items() if old in ds.variables and new not in ds.variables
+    }
+    if rename_dict:
+        ds = ds.rename(rename_dict)
+
+    # 4. Calculate Pressure (Lazy)
+    ds = _add_merra2_pressure(ds)
+
+    # Update history
+    ds = update_history(ds, "Preprocessed MERRA-2 data via Aero Protocol.")
+
+    return ds
+
+
+def _add_merra2_pressure(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Calculate pressure levels lazily for MERRA-2 using ak and bk coefficients.
+    p = ak + bk * surface_pressure
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input dataset.
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset with calculated pressure.
+    """
+    # Look for coefficients. Common names: ak, bk or ap, bp
+    ak = ds.get("ak") if "ak" in ds.variables or "ak" in ds.coords else ds.get("ap")
+    bk = ds.get("bk") if "bk" in ds.variables or "bk" in ds.coords else ds.get("bp")
+    ps = ds.get("surface_pressure") if "surface_pressure" in ds.variables else ds.get("PS")
+
+    if ak is not None and bk is not None and ps is not None:
+        # p = ak + bk * ps
+        # The calculation is fully lazy and backend-agnostic
+        pres = ak + bk * ps
+
+        ds["pres_pa_mid"] = pres.assign_attrs(
+            {
+                "units": "Pa",
+                "long_name": "pressure",
+                "standard_name": "air_pressure",
+                "description": "Pressure calculated as ak + bk * surface_pressure",
+            }
+        )
+        ds = update_history(ds, "Calculated 3D pressure lazily using ak and bk.")
+
+    return ds

--- a/monetio/readers/merra2.py
+++ b/monetio/readers/merra2.py
@@ -1,7 +1,9 @@
 """MERRA-2 Reader"""
 
+import datetime
 from typing import List, Optional, Union
 
+import pandas as pd
 import xarray as xr
 
 from .base import GriddedReader, register_reader
@@ -17,7 +19,11 @@ class MERRA2Reader(GriddedReader):
 
     def open_dataset(
         self,
-        files: Union[str, List[str]],
+        files: Optional[Union[str, List[str]]] = None,
+        dates: Optional[
+            Union[pd.DatetimeIndex, List[datetime.datetime], datetime.datetime, str]
+        ] = None,
+        product: str = "inst1_2d_asm_Nx",
         username: Optional[str] = None,
         password: Optional[str] = None,
         **kwargs,
@@ -27,8 +33,17 @@ class MERRA2Reader(GriddedReader):
 
         Parameters
         ----------
-        files : Union[str, List[str]]
-            File path(s) or URL(s).
+        files : Union[str, List[str]], optional
+            File path(s) or URL(s). If None, will try to build URLs using dates and product.
+        dates : Union[pd.DatetimeIndex, List[datetime], datetime, str], optional
+            Dates to retrieve. Used if files is None.
+        product : str, optional
+            MERRA-2 product short name, by default "inst1_2d_asm_Nx".
+            Common products:
+            - 'inst1_2d_asm_Nx': Instantaneous 2D atmospheric fields
+            - 'tavg1_2d_slv_Nx': Time-averaged 2D surface fields
+            - 'inst3_3d_asm_Np': Instantaneous 3D atmospheric fields (pressure levels)
+            - 'inst3_3d_chm_Np': Instantaneous 3D chemical fields (pressure levels)
         username : str, optional
             NASA Earthdata username. If provided, will setup .netrc.
         password : str, optional
@@ -44,18 +59,89 @@ class MERRA2Reader(GriddedReader):
         if username and password:
             setup_netrc(username, password)
 
+        if files is None:
+            if dates is None:
+                raise ValueError("Either 'files' or 'dates' must be provided.")
+            files = self.build_urls(dates, product=product)
+
         if "preprocess" not in kwargs:
-            kwargs["preprocess"] = merra2_preprocess
+            from functools import partial
+
+            kwargs["preprocess"] = partial(merra2_preprocess, product=product)
 
         ds = super().open_dataset(files, **kwargs)
 
         # Update history
-        ds = update_history(ds, "Read MERRA-2 data.")
+        ds = update_history(ds, f"Read MERRA-2 {product} data.")
 
         return ds
 
+    def build_urls(
+        self,
+        dates: Union[pd.DatetimeIndex, List[datetime.datetime], datetime.datetime, str],
+        product: str = "inst1_2d_asm_Nx",
+    ) -> List[str]:
+        """
+        Build OPeNDAP URLs for MERRA-2 data based on dates and product.
 
-def merra2_preprocess(ds: xr.Dataset) -> xr.Dataset:
+        Parameters
+        ----------
+        dates : Union[pd.DatetimeIndex, List[datetime], datetime, str]
+            Dates to retrieve.
+        product : str, optional
+            MERRA-2 product short name.
+
+        Returns
+        -------
+        List[str]
+            List of OPeNDAP URLs.
+        """
+        if isinstance(dates, (str, datetime.datetime, pd.Timestamp)):
+            dates = pd.DatetimeIndex([pd.to_datetime(dates)])
+        else:
+            dates = pd.to_datetime(dates)
+
+        # Product mapping to GES DISC OPeNDAP paths
+        # Format: (ShortName.Version, CollectionName)
+        prod_map = {
+            "inst1_2d_asm_Nx": ("M2I1NXASM.5.12.4", "inst1_2d_asm_Nx"),
+            "tavg1_2d_slv_Nx": ("M2T1NXSLV.5.12.4", "tavg1_2d_slv_Nx"),
+            "inst3_3d_asm_Np": ("M2I3NPASM.5.12.4", "inst3_3d_asm_Np"),
+            "inst3_3d_chm_Np": ("M2I3NPCHM.5.12.4", "inst3_3d_chm_Np"),
+            "inst3_3d_asm_Nv": ("M2I3NVASM.5.12.4", "inst3_3d_asm_Nv"),
+        }
+
+        if product not in prod_map:
+            raise ValueError(
+                f"Unknown product: {product}. Available: {list(prod_map.keys())}"
+            )
+
+        short_name, coll_name = prod_map[product]
+        base_url = f"https://goldsmr4.gesdisc.eosdis.nasa.gov/opendap/MERRA2/{short_name}"
+
+        urls = []
+        for d in dates.floor("D").unique():
+            # MERRA-2 filenames usually include the date and the product name
+            # Example: MERRA2_400.inst1_2d_asm_Nx.20240101.nc4
+            # The stream ID (400, 300, 200, 100) depends on the year.
+            year = d.year
+            if 1980 <= year <= 1991:
+                stream = "100"
+            elif 1992 <= year <= 2000:
+                stream = "200"
+            elif 2001 <= year <= 2010:
+                stream = "300"
+            else:
+                stream = "400"
+
+            date_str = d.strftime("%Y%m%d")
+            url = f"{base_url}/{d.strftime('%Y/%m')}/MERRA2_{stream}.{coll_name}.{date_str}.nc4"
+            urls.append(url)
+
+        return urls
+
+
+def merra2_preprocess(ds: xr.Dataset, product: Optional[str] = None) -> xr.Dataset:
     """
     Preprocess MERRA-2 dataset: standardize coordinates and metadata.
 
@@ -63,6 +149,8 @@ def merra2_preprocess(ds: xr.Dataset) -> xr.Dataset:
     ----------
     ds : xr.Dataset
         Input dataset.
+    product : str, optional
+        MERRA-2 product short name.
 
     Returns
     -------

--- a/monetio/readers/merra2.py
+++ b/monetio/readers/merra2.py
@@ -112,9 +112,7 @@ class MERRA2Reader(GriddedReader):
         }
 
         if product not in prod_map:
-            raise ValueError(
-                f"Unknown product: {product}. Available: {list(prod_map.keys())}"
-            )
+            raise ValueError(f"Unknown product: {product}. Available: {list(prod_map.keys())}")
 
         short_name, coll_name = prod_map[product]
         base_url = f"https://goldsmr4.gesdisc.eosdis.nasa.gov/opendap/MERRA2/{short_name}"

--- a/monetio/readers/nasa_utils.py
+++ b/monetio/readers/nasa_utils.py
@@ -1,0 +1,53 @@
+import os
+import stat
+from netrc import netrc
+
+
+def setup_netrc(username, password, machine="urs.earthdata.nasa.gov"):
+    """
+    Setup .netrc file with given credentials for a machine.
+
+    Parameters
+    ----------
+    username : str
+        NASA Earthdata username.
+    password : str
+        NASA Earthdata password.
+    machine : str, optional
+        Machine name, by default "urs.earthdata.nasa.gov".
+    """
+    netrc_path = os.path.expanduser("~/.netrc")
+
+    # Check if file exists and has credentials for this machine
+    if os.path.exists(netrc_path):
+        try:
+            n = netrc(netrc_path)
+            if n.authenticators(machine):
+                # Machine already exists in .netrc
+                return
+        except Exception:
+            # Failed to parse, maybe it's empty or corrupt.
+            # We'll try to append anyway or create a new one.
+            pass
+
+    # Ensure the directory exists
+    os.makedirs(os.path.dirname(netrc_path), exist_ok=True)
+
+    # Append to or create .netrc
+    # We use a+ to read and append
+    mode = "a" if os.path.exists(netrc_path) else "w"
+    with open(netrc_path, mode) as f:
+        # If appending, ensure we start on a new line
+        if mode == "a":
+            # Check if last line ends with newline
+            try:
+                with open(netrc_path, "rb") as rb:
+                    rb.seek(-1, os.SEEK_END)
+                    if rb.read(1) != b"\n":
+                        f.write("\n")
+            except OSError:
+                pass
+        f.write(f"machine {machine} login {username} password {password}\n")
+
+    # Ensure proper permissions (600)
+    os.chmod(netrc_path, stat.S_IRUSR | stat.S_IWUSR)

--- a/tests/test_aero_merra2.py
+++ b/tests/test_aero_merra2.py
@@ -1,0 +1,100 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from monetio.readers.merra2 import MERRA2Reader
+
+
+@pytest.fixture
+def mock_merra2_dataset():
+    """Create a mock MERRA2 dataset for testing."""
+    lat = np.linspace(-90, 90, 10)
+    lon = np.linspace(-180, 180, 20)
+    lev = np.arange(1, 73)
+    time = pd.date_range("2023-01-01", periods=1)
+
+    ds = xr.Dataset(
+        coords={
+            "lat": (["lat"], lat),
+            "lon": (["lon"], lon),
+            "lev": (["lev"], lev),
+            "time": (["time"], time),
+        }
+    )
+
+    # Add ak, bk coefficients (standard for MERRA-2)
+    ds["ak"] = (["lev"], np.linspace(0, 1000, 72))
+    ds["bk"] = (["lev"], np.linspace(1, 0, 72))
+
+    # Add surface pressure and temperature
+    shape_sfc = (len(time), len(lat), len(lon))
+    ds["PS"] = (["time", "lat", "lon"], np.full(shape_sfc, 101325.0))
+    ds["T"] = (
+        ["time", "lev", "lat", "lon"],
+        np.random.rand(len(time), len(lev), len(lat), len(lon)) + 273.15,
+    )
+
+    # Set attributes
+    ds.lat.attrs = {"units": "degrees_north", "long_name": "latitude"}
+    ds.lon.attrs = {"units": "degrees_east", "long_name": "longitude"}
+    ds.lev.attrs = {"units": "level", "long_name": "vertical_level"}
+    ds.PS.attrs = {"units": "Pa", "long_name": "surface_pressure"}
+    ds.T.attrs = {"units": "K", "long_name": "temperature"}
+
+    return ds
+
+
+def test_merra2_reader_basic(mock_merra2_dataset, tmp_path):
+    """Test MERRA2Reader with a mock dataset."""
+    test_file = tmp_path / "test_merra2.nc"
+    mock_merra2_dataset.to_netcdf(test_file)
+
+    reader = MERRA2Reader()
+    ds = reader.open_dataset(files=str(test_file))
+
+    # Check standardization
+    assert "latitude" in ds.coords
+    assert "longitude" in ds.coords
+    assert ds.latitude.ndim == 2
+    assert ds.longitude.ndim == 2
+    assert "y" in ds.dims
+    assert "x" in ds.dims
+    assert "z" in ds.dims
+
+    # Check variable renaming
+    assert "surface_pressure" in ds.variables
+    assert "temperature" in ds.variables
+
+    # Check pressure calculation
+    assert "pres_pa_mid" in ds.variables
+    assert ds.pres_pa_mid.attrs["units"] == "Pa"
+
+    # Verify calculation: p = ak + bk * ps
+    # For a specific point
+    expected_p = (
+        mock_merra2_dataset.ak.values[0]
+        + mock_merra2_dataset.bk.values[0] * mock_merra2_dataset.PS.values[0, 0, 0]
+    )
+    # In processed ds, z dimension is levelled (usually 1 is top, 72 is bottom in MERRA2, but check sorting)
+    # standardize_satellite_coords might not flip z automatically unless specified.
+    # Our reader just uses z_dim=["lev", ...].
+
+    # We can check the values directly
+    calculated_p = ds.pres_pa_mid.isel(time=0, z=0, y=0, x=0).values
+    # In mock, ak[0]=0, bk[0]=1, PS=101325 => expected_p = 101325
+    assert np.allclose(calculated_p, expected_p)
+
+
+def test_merra2_lazy_loading(mock_merra2_dataset, tmp_path):
+    """Test MERRA2Reader with lazy loading (Dask)."""
+    test_file = tmp_path / "test_merra2_lazy.nc"
+    mock_merra2_dataset.to_netcdf(test_file)
+
+    reader = MERRA2Reader()
+    # XarrayDriver should use dask if chunks are provided or lazy=True
+    ds = reader.open_dataset(files=str(test_file), chunks={"time": 1})
+
+    assert ds.pres_pa_mid.chunks is not None
+    assert "history" in ds.attrs
+    assert "Preprocessed MERRA-2 data via Aero Protocol." in ds.attrs["history"]

--- a/tests/test_aero_merra2.py
+++ b/tests/test_aero_merra2.py
@@ -98,3 +98,34 @@ def test_merra2_lazy_loading(mock_merra2_dataset, tmp_path):
     assert ds.pres_pa_mid.chunks is not None
     assert "history" in ds.attrs
     assert "Preprocessed MERRA-2 data via Aero Protocol." in ds.attrs["history"]
+
+
+def test_merra2_build_urls():
+    """Test URL building logic for MERRA-2."""
+    reader = MERRA2Reader()
+    urls = reader.build_urls("2024-01-01", product="inst1_2d_asm_Nx")
+    assert len(urls) == 1
+    assert "M2I1NXASM.5.12.4" in urls[0]
+    assert "MERRA2_400.inst1_2d_asm_Nx.20240101.nc4" in urls[0]
+
+    urls_old = reader.build_urls("1990-01-01", product="inst1_2d_asm_Nx")
+    assert "MERRA2_100" in urls_old[0]
+
+    with pytest.raises(ValueError, match="Unknown product"):
+        reader.build_urls("2024-01-01", product="invalid_product")
+
+
+def test_merra2_open_dataset_with_dates(monkeypatch):
+    """Test open_dataset with dates instead of files."""
+    reader = MERRA2Reader()
+
+    def mock_open(self, files, **kwargs):
+        return xr.Dataset(attrs={"files_opened": files})
+
+    # Mock the XarrayDriver.open (or GriddedReader.open_dataset indirectly)
+    # Actually it's easier to mock the super().open_dataset or the build_urls
+    monkeypatch.setattr("monetio.readers.base.GriddedReader.open_dataset", mock_open)
+
+    ds = reader.open_dataset(dates="2024-01-01", product="inst1_2d_asm_Nx")
+    assert "files_opened" in ds.attrs
+    assert "MERRA2_400.inst1_2d_asm_Nx.20240101.nc4" in ds.attrs["files_opened"][0]


### PR DESCRIPTION
This change adds a new reader for MERRA-2 data to the `monetio.readers` module. The reader follows the project's "Aero Protocol" for Earth Science data, ensuring backend-agnostic lazy evaluation using Xarray and Dask.

Key features include:
1. **Credential Management**: A new `setup_netrc` utility is provided to automatically configure NASA Earthdata credentials in the user's `~/.netrc` file when `username` and `password` are passed to `monetio.load("merra2", ...)`.
2. **Hybrid Pressure Calculation**: Vertical coordinates are automatically handled by calculating mid-layer pressure using the hybrid sigma-pressure coefficients (`ak` and `bk`) typically found in MERRA-2 files.
3. **Standardization**: Latitude and longitude are standardized and broadcast to 2D arrays, and standard dimensions (`x`, `y`, `z`, `time`) are assigned for consistency with other readers in the library.
4. **Testing**: New tests in `tests/test_aero_merra2.py` verify that the reader correctly standardizes mock MERRA-2 datasets and performs pressure calculations lazily.

---
*PR created automatically by Jules for task [12781025579918309757](https://jules.google.com/task/12781025579918309757) started by @bbakernoaa*