### PR TITLE
Add MPLNET and EARLINET readers

### DIFF
--- a/monetio/__init__.py
+++ b/monetio/__init__.py
@@ -116,6 +116,8 @@ _READER_MODULES = {
     "geoms": ".readers.geoms",
     "gml_ozonesonde": ".readers.gml_ozonesonde",
     "igra2": ".readers.igra2",
+    "mplnet": ".readers.mplnet",
+    "earlinet": ".readers.earlinet",
     # Sat
     "goes": ".readers.goes",
     "nesdis_edr_viirs": ".readers.nesdis_edr_viirs",

--- a/monetio/obs/earlinet.py
+++ b/monetio/obs/earlinet.py
@@ -1,0 +1,16 @@
+"""
+EARLINET Reader Redirection
+"""
+
+from ..readers.earlinet import EARLINETReader
+
+
+def add_data(
+    files,
+    **kwargs,
+):
+    """Retrieve and load EARLINET data."""
+    return EARLINETReader().open_dataset(
+        files=files,
+        **kwargs,
+    )

--- a/monetio/obs/mplnet.py
+++ b/monetio/obs/mplnet.py
@@ -1,0 +1,16 @@
+"""
+MPLNET Reader Redirection
+"""
+
+from ..readers.mplnet import MPLNETReader
+
+
+def add_data(
+    files,
+    **kwargs,
+):
+    """Retrieve and load MPLNET data."""
+    return MPLNETReader().open_dataset(
+        files=files,
+        **kwargs,
+    )

--- a/monetio/readers/earlinet.py
+++ b/monetio/readers/earlinet.py
@@ -1,0 +1,85 @@
+"""EARLINET Reader"""
+
+from typing import List, Union
+
+import xarray as xr
+
+from .base import GriddedReader, register_reader
+from .sat_utils import update_history
+
+
+@register_reader("earlinet")
+class EARLINETReader(GriddedReader):
+    """
+    Reader for EARLINET (European Aerosol Research Lidar Network) NetCDF data.
+    """
+
+    def open_dataset(self, files: Union[str, List[str]], **kwargs) -> xr.Dataset:
+        """
+        Retrieve and load EARLINET data.
+
+        Parameters
+        ----------
+        files : Union[str, List[str]]
+            File path, list of paths, or glob pattern.
+        **kwargs : dict
+            Additional arguments passed to xarray.open_mfdataset.
+
+        Returns
+        -------
+        xr.Dataset
+            The loaded EARLINET data.
+        """
+        # Default to combined dimensions if not specified
+        kwargs.setdefault("combine", "by_coords")
+
+        # Use XarrayDriver (via GriddedReader) to open
+        ds = super().open_dataset(files, preprocess=earlinet_preprocess, **kwargs)
+
+        return ds
+
+
+def earlinet_preprocess(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Preprocess EARLINET dataset: standardize coordinates and dimensions.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input EARLINET dataset.
+
+    Returns
+    -------
+    xr.Dataset
+        Preprocessed dataset.
+    """
+    # 1. Standardize Time
+    # EARLINET NetCDF files are usually CF compliant and xarray handles them.
+
+    # 2. Rename Dimensions/Coordinates
+    # altitude is usually a coordinate/dimension already named 'altitude' or 'height'.
+    # If it's something else, we can rename it.
+    if "height" in ds.dims and "altitude" not in ds.dims:
+        ds = ds.rename({"height": "altitude"})
+
+    # 3. Coordinate handling
+    # Ensure latitude and longitude are coordinates
+    coord_vars = ["latitude", "longitude", "altitude", "time", "wavelength"]
+    actual_coords = [v for v in coord_vars if v in ds.variables]
+    if actual_coords:
+        ds = ds.set_coords(actual_coords)
+
+    # 4. Standard attributes
+    if "altitude" in ds.coords:
+        ds["altitude"].attrs.update({"units": "m", "standard_name": "altitude", "positive": "up"})
+
+    if "latitude" in ds.coords:
+        ds["latitude"].attrs.update({"units": "degrees_north", "standard_name": "latitude"})
+
+    if "longitude" in ds.coords:
+        ds["longitude"].attrs.update({"units": "degrees_east", "standard_name": "longitude"})
+
+    # Update history
+    ds = update_history(ds, "Preprocessed EARLINET data.")
+
+    return ds

--- a/monetio/readers/mplnet.py
+++ b/monetio/readers/mplnet.py
@@ -1,0 +1,86 @@
+"""MPLNET Reader"""
+
+from typing import List, Union
+
+import xarray as xr
+
+from .base import GriddedReader, register_reader
+from .sat_utils import update_history
+
+
+@register_reader("mplnet")
+class MPLNETReader(GriddedReader):
+    """
+    Reader for MPLNET (NASA Micro-Pulse Lidar Network) V3 NetCDF data.
+    """
+
+    def open_dataset(self, files: Union[str, List[str]], **kwargs) -> xr.Dataset:
+        """
+        Retrieve and load MPLNET data.
+
+        Parameters
+        ----------
+        files : Union[str, List[str]]
+            File path, list of paths, or glob pattern.
+        **kwargs : dict
+            Additional arguments passed to xarray.open_mfdataset.
+
+        Returns
+        -------
+        xr.Dataset
+            The loaded MPLNET data.
+        """
+        # Default to combined dimensions if not specified
+        kwargs.setdefault("combine", "by_coords")
+
+        # Use XarrayDriver (via GriddedReader) to open
+        ds = super().open_dataset(files, preprocess=mplnet_preprocess, **kwargs)
+
+        return ds
+
+
+def mplnet_preprocess(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Preprocess MPLNET dataset: standardize coordinates and dimensions.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Input MPLNET dataset.
+
+    Returns
+    -------
+    xr.Dataset
+        Preprocessed dataset.
+    """
+    # 1. Standardize Time
+    # MPLNET often has 'time' as double (days since start of year or similar)
+    # but modern V3 should be CF compliant and xarray should handle it.
+    # If not, we might need custom logic.
+
+    # 2. Rename Dimensions/Coordinates
+    rename_vars = {}
+    if "surface_altitude" in ds.variables:
+        rename_vars["surface_altitude"] = "elevation"
+
+    if rename_vars:
+        ds = ds.rename_vars(rename_vars)
+
+    # 3. Unit Conversions
+    # elevation (surface_altitude) is in km in MPLNET V3
+    if "elevation" in ds.coords or "elevation" in ds.data_vars:
+        if ds["elevation"].attrs.get("units") == "km":
+            ds["elevation"] = ds["elevation"] * 1000.0
+            ds["elevation"].attrs["units"] = "m"
+
+    # 4. Coordinate handling
+    # Ensure latitude and longitude are coordinates
+    coord_vars = ["latitude", "longitude", "elevation", "time"]
+    actual_coords = [v for v in coord_vars if v in ds.variables]
+    if actual_coords:
+        ds = ds.set_coords(actual_coords)
+
+    # Update history
+    ds = update_history(ds, "Preprocessed MPLNET data.")
+
+    return ds

--- a/tests/test_aero_earlinet.py
+++ b/tests/test_aero_earlinet.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+import pytest
+from monetio.readers.earlinet import EARLINETReader
+
+def test_earlinet_reader_basic(tmp_path):
+    # Create a mock EARLINET NetCDF file
+    fn = tmp_path / "ipr_001_20240101.nc"
+
+    # Mock data
+    time_vals = pd.to_datetime(["2024-01-01 12:00:00", "2024-01-01 13:00:00"])
+    alt_vals = np.linspace(500, 10000, 200) # m
+
+    ds_mock = xr.Dataset(
+        data_vars={
+            "backscatter": (("wavelength", "time", "altitude"), np.random.rand(1, 2, 200)),
+            "latitude": ((), 45.82),
+            "longitude": ((), 8.617),
+        },
+        coords={
+            "time": (("time",), time_vals),
+            "altitude": (("altitude",), alt_vals),
+            "wavelength": (("wavelength",), [1064.0]),
+        },
+        attrs={
+            "title": "EARLINET Data",
+            "station_ID": "ipr",
+        }
+    )
+    ds_mock.latitude.attrs["units"] = "degrees_north"
+    ds_mock.longitude.attrs["units"] = "degrees_east"
+    ds_mock.altitude.attrs["units"] = "m"
+    ds_mock.backscatter.attrs["units"] = "m-1*sr-1"
+
+    ds_mock.to_netcdf(fn)
+
+    reader = EARLINETReader()
+
+    # Test Eager
+    ds = reader.open_dataset(files=str(fn), lazy=False)
+    assert isinstance(ds, xr.Dataset)
+    assert "backscatter" in ds.data_vars
+    assert "latitude" in ds.coords
+    assert "longitude" in ds.coords
+    assert "wavelength" in ds.coords
+    assert ds.latitude.attrs["units"] == "degrees_north"
+    assert ds.longitude.attrs["units"] == "degrees_east"
+    assert "history" in ds.attrs
+    assert "Preprocessed EARLINET data" in ds.attrs["history"]
+
+    # Test Lazy
+    ds_lazy = reader.open_dataset(files=str(fn), lazy=True)
+    assert isinstance(ds_lazy, xr.Dataset)
+    assert ds_lazy.backscatter.chunks is not None
+    assert "latitude" in ds_lazy.coords
+    assert "longitude" in ds_lazy.coords
+
+def test_earlinet_load_universal(tmp_path):
+    import monetio
+    # Create a mock EARLINET NetCDF file
+    fn = tmp_path / "ipr_001_20240101_2.nc"
+    ds_mock = xr.Dataset(
+        data_vars={
+            "backscatter": (("wavelength", "time", "altitude"), np.random.rand(1, 1, 10)),
+            "latitude": ((), 45.82),
+            "longitude": ((), 8.617),
+        },
+        coords={
+            "time": (("time",), [pd.Timestamp("2024-01-01")]),
+            "altitude": (("altitude",), np.arange(10)),
+            "wavelength": (("wavelength",), [1064.0]),
+        }
+    )
+    ds_mock.to_netcdf(fn)
+
+    ds = monetio.load("earlinet", files=str(fn))
+    assert isinstance(ds, xr.Dataset)
+    assert "backscatter" in ds.data_vars

--- a/tests/test_aero_earlinet.py
+++ b/tests/test_aero_earlinet.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
-import pytest
+
 from monetio.readers.earlinet import EARLINETReader
+
 
 def test_earlinet_reader_basic(tmp_path):
     # Create a mock EARLINET NetCDF file
@@ -10,7 +11,7 @@ def test_earlinet_reader_basic(tmp_path):
 
     # Mock data
     time_vals = pd.to_datetime(["2024-01-01 12:00:00", "2024-01-01 13:00:00"])
-    alt_vals = np.linspace(500, 10000, 200) # m
+    alt_vals = np.linspace(500, 10000, 200)  # m
 
     ds_mock = xr.Dataset(
         data_vars={
@@ -26,7 +27,7 @@ def test_earlinet_reader_basic(tmp_path):
         attrs={
             "title": "EARLINET Data",
             "station_ID": "ipr",
-        }
+        },
     )
     ds_mock.latitude.attrs["units"] = "degrees_north"
     ds_mock.longitude.attrs["units"] = "degrees_east"
@@ -56,8 +57,10 @@ def test_earlinet_reader_basic(tmp_path):
     assert "latitude" in ds_lazy.coords
     assert "longitude" in ds_lazy.coords
 
+
 def test_earlinet_load_universal(tmp_path):
     import monetio
+
     # Create a mock EARLINET NetCDF file
     fn = tmp_path / "ipr_001_20240101_2.nc"
     ds_mock = xr.Dataset(
@@ -70,7 +73,7 @@ def test_earlinet_load_universal(tmp_path):
             "time": (("time",), [pd.Timestamp("2024-01-01")]),
             "altitude": (("altitude",), np.arange(10)),
             "wavelength": (("wavelength",), [1064.0]),
-        }
+        },
     )
     ds_mock.to_netcdf(fn)
 

--- a/tests/test_aero_mplnet.py
+++ b/tests/test_aero_mplnet.py
@@ -1,0 +1,79 @@
+import numpy as np
+import pandas as pd
+import xarray as xr
+import pytest
+from monetio.readers.mplnet import MPLNETReader
+
+def test_mplnet_reader_basic(tmp_path):
+    # Create a mock MPLNET V3 NetCDF file
+    fn = tmp_path / "MPLNET_V3_L1_NRB_20240101_SITE.nc"
+
+    # Mock data
+    time_vals = pd.to_datetime(["2024-01-01 00:00:00", "2024-01-01 00:01:00"])
+    alt_vals = np.linspace(0.1, 10.0, 100) # km
+
+    ds_mock = xr.Dataset(
+        data_vars={
+            "nrb": (("time", "altitude"), np.random.rand(2, 100)),
+            "latitude": (("time",), [40.0, 40.0]),
+            "longitude": (("time",), [-80.0, -80.0]),
+            "surface_altitude": (("time",), [0.5, 0.5]), # km
+        },
+        coords={
+            "time": (("time",), time_vals),
+            "altitude": (("altitude",), alt_vals),
+        },
+        attrs={
+            "title": "MPLNET V3 NRB Data",
+        }
+    )
+    ds_mock.surface_altitude.attrs["units"] = "km"
+    ds_mock.latitude.attrs["units"] = "degrees_north"
+    ds_mock.longitude.attrs["units"] = "degrees_east"
+    ds_mock.altitude.attrs["units"] = "km"
+
+    ds_mock.to_netcdf(fn)
+
+    reader = MPLNETReader()
+
+    # Test Eager
+    ds = reader.open_dataset(files=str(fn), lazy=False)
+    assert isinstance(ds, xr.Dataset)
+    assert "nrb" in ds.data_vars
+    assert "elevation" in ds.coords
+    assert ds.elevation.attrs["units"] == "m"
+    assert ds.elevation.values[0] == 500.0
+    assert "latitude" in ds.coords
+    assert "longitude" in ds.coords
+    assert "history" in ds.attrs
+    assert "Preprocessed MPLNET data" in ds.attrs["history"]
+
+    # Test Lazy
+    ds_lazy = reader.open_dataset(files=str(fn), lazy=True)
+    assert isinstance(ds_lazy, xr.Dataset)
+    assert ds_lazy.nrb.chunks is not None
+    assert "elevation" in ds_lazy.coords
+    # Check that unit conversion was lazy
+    assert "elevation" in ds_lazy.coords
+    assert ds_lazy.elevation.attrs["units"] == "m"
+
+def test_mplnet_load_universal(tmp_path):
+    import monetio
+    # Create a mock MPLNET V3 NetCDF file
+    fn = tmp_path / "MPLNET_V3_L1_NRB_20240101_SITE2.nc"
+    ds_mock = xr.Dataset(
+        data_vars={
+            "nrb": (("time", "altitude"), np.random.rand(1, 10)),
+            "latitude": (("time",), [40.0]),
+            "longitude": (("time",), [-80.0]),
+        },
+        coords={
+            "time": (("time",), [pd.Timestamp("2024-01-01")]),
+            "altitude": (("altitude",), np.arange(10)),
+        }
+    )
+    ds_mock.to_netcdf(fn)
+
+    ds = monetio.load("mplnet", files=str(fn))
+    assert isinstance(ds, xr.Dataset)
+    assert "nrb" in ds.data_vars

--- a/tests/test_aero_mplnet.py
+++ b/tests/test_aero_mplnet.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pandas as pd
 import xarray as xr
-import pytest
+
 from monetio.readers.mplnet import MPLNETReader
+
 
 def test_mplnet_reader_basic(tmp_path):
     # Create a mock MPLNET V3 NetCDF file
@@ -10,14 +11,14 @@ def test_mplnet_reader_basic(tmp_path):
 
     # Mock data
     time_vals = pd.to_datetime(["2024-01-01 00:00:00", "2024-01-01 00:01:00"])
-    alt_vals = np.linspace(0.1, 10.0, 100) # km
+    alt_vals = np.linspace(0.1, 10.0, 100)  # km
 
     ds_mock = xr.Dataset(
         data_vars={
             "nrb": (("time", "altitude"), np.random.rand(2, 100)),
             "latitude": (("time",), [40.0, 40.0]),
             "longitude": (("time",), [-80.0, -80.0]),
-            "surface_altitude": (("time",), [0.5, 0.5]), # km
+            "surface_altitude": (("time",), [0.5, 0.5]),  # km
         },
         coords={
             "time": (("time",), time_vals),
@@ -25,7 +26,7 @@ def test_mplnet_reader_basic(tmp_path):
         },
         attrs={
             "title": "MPLNET V3 NRB Data",
-        }
+        },
     )
     ds_mock.surface_altitude.attrs["units"] = "km"
     ds_mock.latitude.attrs["units"] = "degrees_north"
@@ -57,8 +58,10 @@ def test_mplnet_reader_basic(tmp_path):
     assert "elevation" in ds_lazy.coords
     assert ds_lazy.elevation.attrs["units"] == "m"
 
+
 def test_mplnet_load_universal(tmp_path):
     import monetio
+
     # Create a mock MPLNET V3 NetCDF file
     fn = tmp_path / "MPLNET_V3_L1_NRB_20240101_SITE2.nc"
     ds_mock = xr.Dataset(
@@ -70,7 +73,7 @@ def test_mplnet_load_universal(tmp_path):
         coords={
             "time": (("time",), [pd.Timestamp("2024-01-01")]),
             "altitude": (("altitude",), np.arange(10)),
-        }
+        },
     )
     ds_mock.to_netcdf(fn)
 


### PR DESCRIPTION
Integrated MPLNET and EARLINET readers into `monetio` using the `GriddedReader` base class. Standardized coordinates and units during preprocessing to ensure CF compliance and consistency with other readers. Added unit tests for both eager and lazy loading.

---
*PR created automatically by Jules for task [15418677643143310967](https://jules.google.com/task/15418677643143310967) started by @bbakernoaa*