### PR TITLE
Modernize NESDIS FRP reader via Aero Protocol

### DIFF
--- a/monetio/readers/nesdis_frp.py
+++ b/monetio/readers/nesdis_frp.py
@@ -26,6 +26,7 @@ class NESDISFRPReader(GriddedReader):
         date: Union[datetime.datetime, str, pd.Timestamp],
         ftype: str = "meanFRP",
         datapath: str = ".",
+        lazy: bool = False,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -33,12 +34,14 @@ class NESDISFRPReader(GriddedReader):
 
         Parameters
         ----------
-        date : datetime.datetime or str
+        date : datetime.datetime, str, or pd.Timestamp
             Date to retrieve.
         ftype : str, optional
             Type of FRP data (e.g., 'meanFRP'). Default is 'meanFRP'.
         datapath : str, optional
             Local path to store downloaded files. Default is '.'.
+        lazy : bool, optional
+            Whether to read data lazily using Dask, by default False.
         **kwargs : dict
             Additional arguments.
 
@@ -46,11 +49,16 @@ class NESDISFRPReader(GriddedReader):
         -------
         xr.Dataset
             The NESDIS FRP dataset.
+
+        Examples
+        --------
+        >>> reader = NESDISFRPReader()
+        >>> ds = reader.open_dataset("2023-01-01", ftype="meanFRP")
         """
         date = pd.Timestamp(date)
 
         if not os.path.exists(datapath):
-            os.makedirs(datapath)
+            os.makedirs(datapath, exist_ok=True)
 
         # Download tiles (1-6)
         files = self.download_data(date, ftype=ftype, datapath=datapath)
@@ -58,21 +66,44 @@ class NESDISFRPReader(GriddedReader):
         das = []
         for i, fname in enumerate(files):
             tile_num = i + 1
-            da = self.read_tile(fname, tile=tile_num)
+            da = self.read_tile(fname, tile=tile_num, lazy=lazy)
             das.append(da)
 
         ds = xr.concat(das, dim="tile")
         ds = ds.assign_coords(tile=np.arange(1, 7), time=date).expand_dims("time")
         ds = ds.to_dataset(name=ftype)
 
+        # Scientific Hygiene: Coordinate standardization
+        if "longitude" in ds.coords:
+            ds["longitude"].attrs.update({"units": "degrees_east", "standard_name": "longitude"})
+        if "latitude" in ds.coords:
+            ds["latitude"].attrs.update({"units": "degrees_north", "standard_name": "latitude"})
+
         # Update history
-        ds = update_history(ds, f"Read NESDIS {ftype} data.")
+        ds = update_history(ds, f"Read NESDIS {ftype} data from {len(files)} tiles.")
 
         return ds
 
     def download_data(
         self, date: pd.Timestamp, ftype: str = "meanFRP", datapath: str = "."
     ) -> List[str]:
+        """
+        Download NESDIS FRP data from the GSCE server.
+
+        Parameters
+        ----------
+        date : pd.Timestamp
+            Date to download.
+        ftype : str, optional
+            File type (e.g., 'meanFRP'), by default "meanFRP".
+        datapath : str, optional
+            Local directory to save files, by default ".".
+
+        Returns
+        -------
+        List[str]
+            List of paths to the downloaded files.
+        """
         yyyymmdd = date.strftime("%Y%m%d")
         url_ftype = f"&files={ftype}."
 
@@ -92,34 +123,93 @@ class NESDISFRPReader(GriddedReader):
         return files
 
     def read_tile(
-        self, fname: str, tile: int = 1, res: str = "C384", dtype: str = "f4"
+        self,
+        fname: str,
+        tile: int = 1,
+        res: str = "C384",
+        dtype: str = "f4",
+        lazy: bool = False,
     ) -> xr.DataArray:
-        from ..util import _import_required
+        """
+        Read a single NESDIS FRP tile from a binary file.
 
-        scipy_io = _import_required("scipy.io")
-        FortranFile = scipy_io.FortranFile
+        Parameters
+        ----------
+        fname : str
+            Path to the binary file.
+        tile : int, optional
+            Tile number (1-6), by default 1.
+        res : str, optional
+            Grid resolution, by default "C384".
+        dtype : str, optional
+            Data type in the binary file, by default "f4".
+        lazy : bool, optional
+            Whether to use Dask for lazy loading, by default False.
 
+        Returns
+        -------
+        xr.DataArray
+            The tile data with coordinates if fv3grid is available.
+        """
+        r = int(res[1:])
+        shape = (r, r)
+
+        if lazy:
+            import dask.array as da
+            from dask import delayed
+
+            # Define delayed reader
+            load_tile = delayed(_read_binary_tile)(fname, res, dtype)
+            data = da.from_delayed(load_tile, shape=shape, dtype=np.dtype(dtype))
+        else:
+            data = _read_binary_tile(fname, res, dtype)
+
+        # Handle Grid and Coordinates
         try:
             import fv3grid as fg
 
-            has_fv3grid = True
-        except ImportError:
-            has_fv3grid = False
-
-        def wrap_longitudes(lon):
-            return (lon + 180) % 360 - 180
-
-        with open(fname, "rb") as f:
-            w = FortranFile(f)
-            a = w.read_reals(dtype=dtype)
-
-        r = int(res[1:])
-        s = a.reshape((r, r), order="F")
-
-        if has_fv3grid:
             grid = fg.get_fv3_grid(res=res, tile=tile)
-            grid["longitude"] = wrap_longitudes(grid.longitude)
-            da = xr.DataArray(s, dims=("x", "y"), coords=grid.coords)
-            return da
+            # Wrap longitudes to [-180, 180]
+            lon = (grid.longitude + 180) % 360 - 180
+            lat = grid.latitude
+            coords = {"latitude": (("x", "y"), lat), "longitude": (("x", "y"), lon)}
+        except ImportError:
+            coords = None
+
+        if coords:
+            da = xr.DataArray(data, dims=("x", "y"), coords=coords)
         else:
-            return xr.DataArray(s, dims=("x", "y"))
+            da = xr.DataArray(data, dims=("x", "y"))
+
+        # Update history on the DataArray if possible
+        da = update_history(da, f"Read tile {tile} from {fname} (lazy={lazy}).")
+
+        return da
+
+
+def _read_binary_tile(fname: str, res: str, dtype: str) -> np.ndarray:
+    """
+    Core binary reading logic for a single tile.
+
+    Parameters
+    ----------
+    fname : str
+        File path.
+    res : str
+        Grid resolution (e.g., 'C384').
+    dtype : str
+        Numpy dtype string.
+
+    Returns
+    -------
+    np.ndarray
+        Reshaped data array.
+    """
+    from scipy.io import FortranFile
+
+    r = int(res[1:])
+    with open(fname, "rb") as f:
+        w = FortranFile(f)
+        a = w.read_reals(dtype=dtype)
+
+    return a.reshape((r, r), order="F")

--- a/tests/test_aero_nesdis_frp.py
+++ b/tests/test_aero_nesdis_frp.py
@@ -1,0 +1,87 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from scipy.io import FortranFile
+
+from monetio.readers.nesdis_frp import NESDISFRPReader
+
+
+def create_mock_frp_tile(filepath, res="C384"):
+    """Create a mock NESDIS FRP binary tile."""
+    r = int(res[1:])
+    # NESDIS FRP uses 2D arrays (r, r)
+    data = np.random.rand(r, r).astype("f4")
+    with open(filepath, "wb") as f:
+        w = FortranFile(f)
+        w.write_record(data.flatten(order="F"))
+    return data
+
+
+@pytest.fixture
+def mock_frp_files(tmp_path):
+    """Create 6 mock FRP tiles for a single date."""
+    datapath = tmp_path / "frp_data"
+    datapath.mkdir()
+    date = pd.Timestamp("2023-01-01")
+    yyyymmdd = date.strftime("%Y%m%d")
+    ftype = "meanFRP"
+
+    files = []
+    expected_data = []
+    for i in range(1, 7):
+        filename = f"{ftype}.{yyyymmdd}.FV3.C384Grid.tile{i}.bin"
+        filepath = datapath / filename
+        data = create_mock_frp_tile(filepath)
+        files.append(str(filepath))
+        expected_data.append(data)
+
+    return date, ftype, str(datapath), expected_data
+
+
+def test_nesdis_frp_eager_lazy(mock_frp_files):
+    """Verify NESDIS FRP reader produces identical results for Eager and Lazy backends."""
+    date, ftype, datapath, expected_data = mock_frp_files
+    reader = NESDISFRPReader()
+
+    # 1. Eager Load
+    ds_eager = reader.open_dataset(date, ftype=ftype, datapath=datapath, lazy=False)
+    assert isinstance(ds_eager[ftype].data, np.ndarray)
+
+    # 2. Lazy Load
+    ds_lazy = reader.open_dataset(date, ftype=ftype, datapath=datapath, lazy=True)
+    try:
+        import dask.array as da
+
+        assert isinstance(ds_lazy[ftype].data, da.Array)
+    except ImportError:
+        pass  # Dask not installed, should still work but as numpy
+
+    # 3. Assert values are identical
+    xr.testing.assert_allclose(ds_eager, ds_lazy)
+
+    # Check shape (time=1, tile=6, x=384, y=384)
+    assert ds_eager[ftype].shape == (1, 6, 384, 384)
+
+    # Check coordinates
+    assert "time" in ds_eager.coords
+    assert "tile" in ds_eager.coords
+    assert ds_eager.time[0] == date
+
+    # Check history
+    assert "history" in ds_eager.attrs
+    assert "Read NESDIS meanFRP data" in ds_eager.attrs["history"]
+    assert "Read tile 1" in ds_eager[ftype].attrs.get("history", "")
+
+
+def test_nesdis_frp_metadata(mock_frp_files):
+    """Test scientific hygiene and coordinate metadata."""
+    date, ftype, datapath, _ = mock_frp_files
+    reader = NESDISFRPReader()
+
+    ds = reader.open_dataset(date, ftype=ftype, datapath=datapath)
+
+    # Check units and names if available
+    # Since fv3grid is likely missing in test env, lat/lon might be missing
+    # but let's check what we DO have.
+    assert ftype in ds.data_vars


### PR DESCRIPTION
This submission modernizes the NESDIS Fire Radiative Power (FRP) reader to follow the Aero Protocol. Key improvements include the addition of optional lazy-loading support via Dask, comprehensive NumPy-style documentation, and enhanced data lineage tracking. A new dual-backend unit test verifies that the reader produces identical results when executed eagerly (NumPy) or lazily (Dask).

---
*PR created automatically by Jules for task [11283529515631537111](https://jules.google.com/task/11283529515631537111) started by @bbakernoaa*