### PR TITLE
Standardize TAI93 Time Parsing via Aero Protocol

### DIFF
--- a/monetio/readers/modis_l2.py
+++ b/monetio/readers/modis_l2.py
@@ -2,11 +2,10 @@
 
 from typing import List, Union
 
-import pandas as pd
 import xarray as xr
 
 from .base import GriddedReader, register_reader
-from .sat_utils import standardize_satellite_coords, update_history
+from .sat_utils import standardize_satellite_coords, tai93_to_datetime, update_history
 
 
 @register_reader("modis_l2")
@@ -94,20 +93,7 @@ def modis_l2_preprocess(ds: xr.Dataset, variable_dict: dict = None) -> xr.Datase
 
     # 2. Add time coordinate if Scan_Start_Time is present
     if "Scan_Start_Time" in ds.variables and "time" not in ds.coords:
-        # Seconds since 1993-01-01 00:00:00 UTC
-        epoch_1993 = pd.Timestamp("1993-01-01", tz="UTC")
-
-        def _calc_time(s):
-            return (epoch_1993.to_datetime64() + (s * 1e9).astype("timedelta64[ns]")).astype(
-                "datetime64[ns]"
-            )
-
-        ds["time"] = xr.apply_ufunc(
-            _calc_time,
-            ds["Scan_Start_Time"],
-            dask="parallelized",
-            output_dtypes=["datetime64[ns]"],
-        )
+        ds["time"] = tai93_to_datetime(ds["Scan_Start_Time"])
         ds = ds.set_coords("time")
 
     # 3. Apply variable_dict transformations (scale, minimum, maximum)

--- a/monetio/readers/mopitt.py
+++ b/monetio/readers/mopitt.py
@@ -1,14 +1,12 @@
 """MOPITT Reader"""
 
-import datetime
 from typing import List, Union
 
 import numpy as np
-import pandas as pd
 import xarray as xr
 
 from .base import GriddedReader, register_reader
-from .sat_utils import standardize_satellite_coords, update_history
+from .sat_utils import standardize_satellite_coords, tai93_to_datetime, update_history
 
 MOPITT_MISSING = -9999.0
 
@@ -110,11 +108,11 @@ def mopitt_preprocess(ds: xr.Dataset) -> xr.Dataset:
             if isinstance(start_time, (list, np.ndarray)):
                 start_time = start_time[0]
             # MOPITT uses seconds since 1993-01-01
-            dt = datetime.datetime(1993, 1, 1) + datetime.timedelta(seconds=float(start_time))
-            time_val = pd.to_datetime(dt)
+            # Wrap in DataArray to use standardized utility
+            time_da = xr.DataArray([float(start_time)], dims=("time",))
             if "time" not in ds.dims:
                 ds = ds.expand_dims("time")
-            ds = ds.assign_coords(time=("time", [time_val]))
+            ds = ds.assign_coords(time=tai93_to_datetime(time_da))
 
     # 4. Handle Missing Values
     for var in ds.data_vars:

--- a/monetio/readers/omps.py
+++ b/monetio/readers/omps.py
@@ -1,13 +1,12 @@
 """OMPS Reader"""
 
-import datetime
 from typing import List, Union
 
 import pandas as pd
 import xarray as xr
 
 from .base import GriddedReader, register_reader
-from .sat_utils import apply_lazy_conversion, standardize_satellite_coords, update_history
+from .sat_utils import standardize_satellite_coords, tai93_to_datetime, update_history
 
 
 @register_reader("omps")
@@ -151,15 +150,7 @@ def _preprocess_nmto3_l2(ds: xr.Dataset) -> xr.Dataset:
 
     # Handle Time (Lazy)
     if "time_raw" in ds.variables:
-        # Time is seconds since 1993-01-01
-        ref_date = datetime.datetime(1993, 1, 1)
-
-        def _convert_time(t):
-            return pd.to_datetime(t, unit="s", origin=ref_date)
-
-        # Use standardized utility for lazy conversion
-        ds["time"] = apply_lazy_conversion(ds["time_raw"], _convert_time, "datetime64[ns]")
-
+        ds["time"] = tai93_to_datetime(ds["time_raw"])
         ds = ds.set_coords("time")
         if "time_raw" in ds.variables:
             ds = ds.drop_vars("time_raw")

--- a/monetio/readers/sat_utils.py
+++ b/monetio/readers/sat_utils.py
@@ -285,7 +285,8 @@ def tai93_to_datetime(time_array: xr.DataArray) -> xr.DataArray:
     """
 
     def _convert(t):
-        return pd.to_datetime(t, unit="s", origin="1993-01-01")
+        # pd.to_datetime expects 1D input
+        return pd.to_datetime(t.ravel(), unit="s", origin="1993-01-01").values.reshape(t.shape)
 
     return apply_lazy_conversion(time_array, _convert, "datetime64[ns]")
 

--- a/monetio/readers/sat_utils.py
+++ b/monetio/readers/sat_utils.py
@@ -265,6 +265,31 @@ def jpss_time_to_datetime(
     return apply_lazy_conversion(time_array, _convert, "datetime64[ns]")
 
 
+def tai93_to_datetime(time_array: xr.DataArray) -> xr.DataArray:
+    """
+    Convert TAI93 time (seconds since 1993-01-01) to datetime64[ns].
+
+    Parameters
+    ----------
+    time_array : xr.DataArray
+        Input time array in seconds since 1993-01-01 00:00:00 UTC.
+
+    Returns
+    -------
+    xr.DataArray
+        Time array in datetime64[ns].
+
+    Examples
+    --------
+    >>> ds["time"] = tai93_to_datetime(ds["Scan_Start_Time"])
+    """
+
+    def _convert(t):
+        return pd.to_datetime(t, unit="s", origin="1993-01-01")
+
+    return apply_lazy_conversion(time_array, _convert, "datetime64[ns]")
+
+
 def add_time_coord(
     ds: xr.Dataset,
     time_val: Optional[datetime.datetime] = None,

--- a/tests/test_aero_time_parsing.py
+++ b/tests/test_aero_time_parsing.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from monetio.readers.sat_utils import tai93_to_datetime
+
+
+def test_tai93_to_datetime_eager_lazy():
+    """Test tai93_to_datetime with both Eager (NumPy) and Lazy (Dask) backends."""
+    # 1. Setup sample data (seconds since 1993-01-01)
+    # 0 -> 1993-01-01
+    # 86400 -> 1993-01-02
+    # 31536000 -> 1994-01-01
+    times = np.array([0.0, 86400.0, 31536000.0])
+    expected = pd.to_datetime(["1993-01-01", "1993-01-02", "1994-01-01"]).values.astype(
+        "datetime64[ns]"
+    )
+
+    da_eager = xr.DataArray(times, dims="time", name="tai93")
+
+    # 2. Test Eager
+    res_eager = tai93_to_datetime(da_eager)
+    assert isinstance(res_eager.data, np.ndarray)
+    np.testing.assert_array_equal(res_eager.values, expected)
+
+    # 3. Test Lazy (Dask)
+    try:
+        import dask.array  # noqa: F401
+
+        da_lazy = da_eager.chunk({"time": 1})
+        res_lazy = tai93_to_datetime(da_lazy)
+
+        assert hasattr(res_lazy.data, "dask")
+        # Verify result is identical to eager
+        np.testing.assert_array_equal(res_lazy.compute().values, expected)
+    except ImportError:
+        pytest.skip("Dask not installed")
+
+
+def test_tai93_to_datetime_precision():
+    """Verify precision for fractional seconds."""
+    # 0.5 seconds
+    times = np.array([0.5])
+    expected = np.datetime64("1993-01-01T00:00:00.500000000")
+
+    da = xr.DataArray(times, dims="time")
+    res = tai93_to_datetime(da)
+
+    np.testing.assert_array_equal(res.values, [expected])

--- a/tests/test_aero_time_parsing.py
+++ b/tests/test_aero_time_parsing.py
@@ -48,3 +48,17 @@ def test_tai93_to_datetime_precision():
     res = tai93_to_datetime(da)
 
     np.testing.assert_array_equal(res.values, [expected])
+
+
+def test_tai93_to_datetime_2d():
+    """Verify that 2D arrays (swaths) are handled correctly."""
+    times = np.array([[0.0, 3600.0], [86400.0, 86400.0 + 3600.0]])
+    expected = pd.to_datetime(
+        ["1993-01-01T00:00:00", "1993-01-01T01:00:00", "1993-01-02T00:00:00", "1993-01-02T01:00:00"]
+    ).values.astype("datetime64[ns]")
+
+    da = xr.DataArray(times, dims=("y", "x"))
+    res = tai93_to_datetime(da)
+
+    assert res.shape == (2, 2)
+    np.testing.assert_array_equal(res.values.ravel(), expected)


### PR DESCRIPTION
I have refactored the time conversion logic for satellite products using the TAI93 epoch (seconds since 1993-01-01). Previously, this logic was duplicated and inconsistent across the `modis_l2`, `mopitt`, and `omps` readers.

By centralizing this into a robust `tai93_to_datetime` utility in `monetio/readers/sat_utils.py`, I have:
1. **Ensured Backend Agnosticism**: The new utility handles both NumPy and Dask arrays lazily via `xr.apply_ufunc` with `dask='parallelized'`.
2. **Improved Maintainability**: Removed redundant local parsing logic and standardized on a single implementation following the Aero Protocol.
3. **Verified Logic**: Added a dedicated test suite that confirms identical results for Eager and Lazy backends and maintains fractional second precision.

This change reduces technical debt and ensures future satellite readers using this common epoch can utilize a verified, high-performance utility.

---
*PR created automatically by Jules for task [12374135665382928633](https://jules.google.com/task/12374135665382928633) started by @bbakernoaa*