### PR TITLE
feat: Support reading large datasets using Kerchunk

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,6 +14,8 @@ We are moving to a unified reader system located in `monetio/readers/`.
 - **Discovery**: The `monetio.load()` function provides a single entry point for all data sources.
 - **Maintainability**: Common logic (like S3 access, coordinate renaming, and lazy loading) is centralized in drivers and base classes.
 - **Lazy Loading**: Readers are registered and loaded only when needed, reducing initial import time.
+- **Performance (Kerchunk)**: For large gridded datasets (MERRA2, GFS, ICAP), readers leverage `use_kerchunk=True` via the Xarray driver to bypass `open_mfdataset` overhead. By pre-computing references to `kerchunk_file`, datasets map into memory virtually via the Zarr engine.
+
 
 ## Deprecation of Legacy Modules
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -93,6 +93,21 @@ monetio aqs -d 2023-01-01 -p OZONE -p PM2.5 -o epa_data.nc
 monetio openaq -d 2023-01-01 -o openaq_global.csv --as-pandas
 ```
 
+
+## Pre-processing Large Datasets (Kerchunk)
+
+For very large gridded datasets (e.g., MERRA2, GFS, RRFS), `xarray.open_mfdataset` can be slow to build the initial coordinate map. MONETIO provides a command to pre-process these files into a single Kerchunk reference JSON file. This allows instant loading of the virtual Zarr dataset later.
+
+```bash
+monetio kerchunk "s3://noaa-rrfs-pds/rrfs_a/20230101/00/control/rrfs.t00z.prslev.f*.nc" -o rrfs_cache.json
+```
+
+Options:
+- `-o, --output PATH`: (Required) Path to save the output JSON reference file.
+- `--concat-dim TEXT`: Dimension to concatenate the files along (default: `time`).
+
+Once generated, you can load the data natively using the Python API by passing `use_kerchunk=True` and `kerchunk_file="rrfs_cache.json"` to the reader.
+
 ## Data Handling
 
 ### NetCDF vs. CSV

--- a/monetio/cli.py
+++ b/monetio/cli.py
@@ -240,6 +240,21 @@ def kerchunk(files, output, concat_dim):
         click.echo("Error: No files provided.")
         return
 
+    # Expand any glob strings (e.g. s3://bucket/*.nc)
+    from monetio.readers.drivers import FileUtility
+    expanded_files = []
+    for f in files:
+        try:
+            expanded_files.extend(FileUtility.expand_paths(f))
+        except FileNotFoundError:
+            pass
+
+    if not expanded_files:
+        click.echo("Error: No valid files found matching patterns.")
+        return
+
+    files = expanded_files
+
     click.echo(f"Kerchunking {len(files)} file(s) into {output}...")
     from monetio.readers.drivers import XarrayDriver
 

--- a/monetio/cli.py
+++ b/monetio/cli.py
@@ -242,6 +242,7 @@ def kerchunk(files, output, concat_dim):
 
     # Expand any glob strings (e.g. s3://bucket/*.nc)
     from monetio.readers.drivers import FileUtility
+
     expanded_files = []
     for f in files:
         try:

--- a/monetio/cli.py
+++ b/monetio/cli.py
@@ -223,5 +223,35 @@ def openaq(dates, output, n_procs, lazy, as_pandas, wide_fmt):
     handle_save(obj, output, as_pandas)
 
 
+@cli.command()
+@click.argument("files", nargs=-1)
+@click.option(
+    "--output", "-o", required=True, help="Output JSON file path for the Kerchunk reference."
+)
+@click.option(
+    "--concat-dim", default="time", help="Dimension to concatenate along (default 'time')."
+)
+def kerchunk(files, output, concat_dim):
+    """
+    Pre-process files into a single Kerchunk reference JSON map.
+    Especially useful for large geospatial datasets (MERRA2, GFS, etc.).
+    """
+    if not files:
+        click.echo("Error: No files provided.")
+        return
+
+    click.echo(f"Kerchunking {len(files)} file(s) into {output}...")
+    from monetio.readers.drivers import XarrayDriver
+
+    # We use XarrayDriver.open to handle the parsing natively and drop the dataset payload.
+    # It automatically saves the references to `kerchunk_file`.
+    xd = XarrayDriver()
+    try:
+        xd.open(list(files), use_kerchunk=True, kerchunk_file=output, concat_dim=concat_dim)
+        click.echo(f"Successfully generated {output}")
+    except Exception as e:
+        click.echo(f"Error generating Kerchunk reference: {e}")
+
+
 if __name__ == "__main__":
     cli()

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -80,7 +80,7 @@ class XarrayDriver:
     Supports S3 via fsspec.
     """
 
-    def open(self, files: Union[str, List[str]], use_dask: bool = False, **kwargs) -> xr.Dataset:
+    def open(self, files: Union[str, List[str]], use_dask: bool = False, use_kerchunk: bool = False, **kwargs) -> xr.Dataset:
         """
         Open gridded data backend-agnostically.
 
@@ -90,6 +90,9 @@ class XarrayDriver:
             File path(s), URL(s), or glob pattern.
         use_dask : bool, optional
             Whether to use Dask for lazy loading, by default False.
+        use_kerchunk : bool, optional
+            Whether to use Kerchunk to create a virtual Zarr dataset, by default False.
+            Useful for large datasets to avoid xarray.open_mfdataset overhead.
         **kwargs : dict
             Additional arguments passed to xarray open functions.
 
@@ -115,6 +118,79 @@ class XarrayDriver:
         # Extract MONETIO-specific keywords
         preprocess = xr_kwargs.pop("preprocess", None)
         read_method = xr_kwargs.pop("read_method", None)
+
+        if use_kerchunk:
+            try:
+                import ujson  # noqa: F401
+                import zarr  # noqa: F401
+                from kerchunk.combine import MultiZarrToZarr
+                from kerchunk.hdf import SingleHdf5ToZarr
+            except ImportError:
+                raise ImportError(
+                    "kerchunk requires 'kerchunk', 'ujson', and 'zarr'. "
+                    "Install with `pip install kerchunk ujson zarr`."
+                )
+
+            dicts = []
+            for f in file_list:
+                if f.startswith("s3://"):
+                    fs = fsspec.filesystem("s3", anon=xr_kwargs.get("storage_options", {}).get("anon", True))
+                elif f.startswith("http://") or f.startswith("https://"):
+                    fs = fsspec.filesystem("http")
+                else:
+                    fs = fsspec.filesystem("file")
+
+                with fs.open(f, "rb") as infile:
+                    h5chunks = SingleHdf5ToZarr(infile, f)
+                    dicts.append(h5chunks.translate())
+
+            if len(dicts) == 1:
+                refs = dicts[0]
+            else:
+                concat_dim = xr_kwargs.get("concat_dim", "time")
+                mzz = MultiZarrToZarr(dicts, concat_dims=[concat_dim])
+                refs = mzz.translate()
+
+            remote_protocol = "file"
+            remote_options = {}
+            if file_list[0].startswith("s3://"):
+                remote_protocol = "s3"
+                remote_options = xr_kwargs.get("storage_options", {})
+                if "anon" not in remote_options:
+                    remote_options["anon"] = True
+            elif file_list[0].startswith("http"):
+                remote_protocol = "http"
+
+            mapper = fsspec.get_mapper(
+                "reference://",
+                fo=refs,
+                remote_protocol=remote_protocol,
+                remote_options=remote_options,
+            )
+
+            # Clean up xr_kwargs for open_dataset
+            mfdataset_keys = [
+                "combine",
+                "concat_dim",
+                "parallel",
+                "compat",
+                "data_vars",
+                "coords",
+                "ids",
+                "infer_order",
+                "join",
+                "engine",
+                "storage_options",
+            ]
+            for k in mfdataset_keys:
+                xr_kwargs.pop(k, None)
+
+            ds = xr.open_dataset(mapper, engine="zarr", backend_kwargs={"consolidated": False}, consolidated=False, **xr_kwargs)
+
+            if preprocess:
+                ds = preprocess(ds)
+
+            return ds
 
         try:
             # Case A: Single File (Optimized)

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -80,7 +80,13 @@ class XarrayDriver:
     Supports S3 via fsspec.
     """
 
-    def open(self, files: Union[str, List[str]], use_dask: bool = False, use_kerchunk: bool = False, **kwargs) -> xr.Dataset:
+    def open(
+        self,
+        files: Union[str, List[str]],
+        use_dask: bool = False,
+        use_kerchunk: bool = False,
+        **kwargs,
+    ) -> xr.Dataset:
         """
         Open gridded data backend-agnostically.
 
@@ -134,7 +140,9 @@ class XarrayDriver:
             dicts = []
             for f in file_list:
                 if f.startswith("s3://"):
-                    fs = fsspec.filesystem("s3", anon=xr_kwargs.get("storage_options", {}).get("anon", True))
+                    fs = fsspec.filesystem(
+                        "s3", anon=xr_kwargs.get("storage_options", {}).get("anon", True)
+                    )
                 elif f.startswith("http://") or f.startswith("https://"):
                     fs = fsspec.filesystem("http")
                 else:
@@ -185,7 +193,13 @@ class XarrayDriver:
             for k in mfdataset_keys:
                 xr_kwargs.pop(k, None)
 
-            ds = xr.open_dataset(mapper, engine="zarr", backend_kwargs={"consolidated": False}, consolidated=False, **xr_kwargs)
+            ds = xr.open_dataset(
+                mapper,
+                engine="zarr",
+                backend_kwargs={"consolidated": False},
+                consolidated=False,
+                **xr_kwargs,
+            )
 
             if preprocess:
                 ds = preprocess(ds)

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -85,6 +85,7 @@ class XarrayDriver:
         files: Union[str, List[str]],
         use_dask: bool = False,
         use_kerchunk: bool = False,
+        kerchunk_file: str = None,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -99,6 +100,10 @@ class XarrayDriver:
         use_kerchunk : bool, optional
             Whether to use Kerchunk to create a virtual Zarr dataset, by default False.
             Useful for large datasets to avoid xarray.open_mfdataset overhead.
+        kerchunk_file : str, optional
+            Path to save/load the Kerchunk reference JSON file. If provided and the file
+            exists, the references will be loaded from it. If the file does not exist,
+            the references will be computed and saved to this path.
         **kwargs : dict
             Additional arguments passed to xarray open functions.
 
@@ -137,33 +142,56 @@ class XarrayDriver:
                     "Install with `pip install kerchunk ujson zarr`."
                 )
 
-            dicts = []
-            for f in file_list:
-                if f.startswith("s3://"):
-                    fs = fsspec.filesystem(
-                        "s3", anon=xr_kwargs.get("storage_options", {}).get("anon", True)
-                    )
-                elif f.startswith("http://") or f.startswith("https://"):
-                    fs = fsspec.filesystem("http")
+            import os
+
+            refs = None
+            if kerchunk_file is not None and os.path.exists(kerchunk_file):
+                try:
+                    with open(kerchunk_file) as f_ref:
+                        refs = ujson.load(f_ref)
+                except Exception as e:
+                    import warnings
+
+                    warnings.warn(f"Failed to load kerchunk_file {kerchunk_file}: {e}")
+                    refs = None
+
+            if refs is None:
+                dicts = []
+                for f in file_list:
+                    if f.startswith("s3://"):
+                        fs = fsspec.filesystem(
+                            "s3", anon=xr_kwargs.get("storage_options", {}).get("anon", True)
+                        )
+                    elif f.startswith("http://") or f.startswith("https://"):
+                        fs = fsspec.filesystem("http")
+                    else:
+                        fs = fsspec.filesystem("file")
+
+                    with fs.open(f, "rb") as infile:
+                        h5chunks = SingleHdf5ToZarr(infile, f)
+                        dicts.append(h5chunks.translate())
+
+                if len(dicts) == 1:
+                    refs = dicts[0]
                 else:
-                    fs = fsspec.filesystem("file")
+                    concat_dim = xr_kwargs.get("concat_dim", "time")
+                    mzz = MultiZarrToZarr(dicts, concat_dims=[concat_dim])
+                    refs = mzz.translate()
 
-                with fs.open(f, "rb") as infile:
-                    h5chunks = SingleHdf5ToZarr(infile, f)
-                    dicts.append(h5chunks.translate())
+                if kerchunk_file is not None:
+                    try:
+                        with open(kerchunk_file, "w") as f_ref:
+                            ujson.dump(refs, f_ref)
+                    except Exception as e:
+                        import warnings
 
-            if len(dicts) == 1:
-                refs = dicts[0]
-            else:
-                concat_dim = xr_kwargs.get("concat_dim", "time")
-                mzz = MultiZarrToZarr(dicts, concat_dims=[concat_dim])
-                refs = mzz.translate()
+                        warnings.warn(f"Failed to save kerchunk_file {kerchunk_file}: {e}")
 
             remote_protocol = "file"
             remote_options = {}
             if file_list[0].startswith("s3://"):
                 remote_protocol = "s3"
-                remote_options = xr_kwargs.get("storage_options", {})
+                remote_options = dict(xr_kwargs.get("storage_options", {}))
                 if "anon" not in remote_options:
                     remote_options["anon"] = True
             elif file_list[0].startswith("http"):


### PR DESCRIPTION
Implemented the `use_kerchunk` boolean toggle directly into the overarching `XarrayDriver` which sits behind `monetio.load` and other reader primitives. It uses `fsspec` references to evaluate the data map instantly rather than opening and decoding individual NetCDF files overhead like `open_mfdataset` does.

---
*PR created automatically by Jules for task [6285017102078033288](https://jules.google.com/task/6285017102078033288) started by @bbakernoaa*