### PR TITLE
Refactor: Replace Kerchunk with VirtualiZarr v2

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,7 +14,7 @@ We are moving to a unified reader system located in `monetio/readers/`.
 - **Discovery**: The `monetio.load()` function provides a single entry point for all data sources.
 - **Maintainability**: Common logic (like S3 access, coordinate renaming, and lazy loading) is centralized in drivers and base classes.
 - **Lazy Loading**: Readers are registered and loaded only when needed, reducing initial import time.
-- **Performance (Kerchunk)**: For large gridded datasets (MERRA2, GFS, ICAP), readers leverage `use_kerchunk=True` via the Xarray driver to bypass `open_mfdataset` overhead. By pre-computing references to `kerchunk_file`, datasets map into memory virtually via the Zarr engine.
+- **Performance (VirtualiZarr)**: For large gridded datasets (MERRA2, GFS, ICAP), readers leverage `use_virtualizarr=True` via the Xarray driver to bypass `open_mfdataset` overhead. By pre-computing references to `virtualizarr_file`, datasets map into memory virtually via the Zarr engine.
 
 
 ## Deprecation of Legacy Modules

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -94,19 +94,19 @@ monetio openaq -d 2023-01-01 -o openaq_global.csv --as-pandas
 ```
 
 
-## Pre-processing Large Datasets (Kerchunk)
+## Pre-processing Large Datasets (VirtualiZarr)
 
-For very large gridded datasets (e.g., MERRA2, GFS, RRFS), `xarray.open_mfdataset` can be slow to build the initial coordinate map. MONETIO provides a command to pre-process these files into a single Kerchunk reference JSON file. This allows instant loading of the virtual Zarr dataset later.
+For very large gridded datasets (e.g., MERRA2, GFS, RRFS), `xarray.open_mfdataset` can be slow to build the initial coordinate map. MONETIO provides a command to pre-process these files into a single VirtualiZarr reference JSON file. This allows instant loading of the virtual Zarr dataset later.
 
 ```bash
-monetio kerchunk "s3://noaa-rrfs-pds/rrfs_a/20230101/00/control/rrfs.t00z.prslev.f*.nc" -o rrfs_cache.json
+monetio virtualizarr "s3://noaa-rrfs-pds/rrfs_a/20230101/00/control/rrfs.t00z.prslev.f*.nc" -o rrfs_cache.json
 ```
 
 Options:
 - `-o, --output PATH`: (Required) Path to save the output JSON reference file.
 - `--concat-dim TEXT`: Dimension to concatenate the files along (default: `time`).
 
-Once generated, you can load the data natively using the Python API by passing `use_kerchunk=True` and `kerchunk_file="rrfs_cache.json"` to the reader.
+Once generated, you can load the data natively using the Python API by passing `use_virtualizarr=True` and `virtualizarr_file="rrfs_cache.json"` to the reader.
 
 ## Data Handling
 

--- a/monetio/cli.py
+++ b/monetio/cli.py
@@ -223,17 +223,17 @@ def openaq(dates, output, n_procs, lazy, as_pandas, wide_fmt):
     handle_save(obj, output, as_pandas)
 
 
-@cli.command()
+@cli.command(name="virtualizarr")
 @click.argument("files", nargs=-1)
 @click.option(
-    "--output", "-o", required=True, help="Output JSON file path for the Kerchunk reference."
+    "--output", "-o", required=True, help="Output JSON file path for the VirtualiZarr reference."
 )
 @click.option(
     "--concat-dim", default="time", help="Dimension to concatenate along (default 'time')."
 )
-def kerchunk(files, output, concat_dim):
+def virtualizarr(files, output, concat_dim):
     """
-    Pre-process files into a single Kerchunk reference JSON map.
+    Pre-process files into a single VirtualiZarr reference JSON map.
     Especially useful for large geospatial datasets (MERRA2, GFS, etc.).
     """
     if not files:
@@ -256,17 +256,17 @@ def kerchunk(files, output, concat_dim):
 
     files = expanded_files
 
-    click.echo(f"Kerchunking {len(files)} file(s) into {output}...")
+    click.echo(f"Virtualizing {len(files)} file(s) into {output}...")
     from monetio.readers.drivers import XarrayDriver
 
     # We use XarrayDriver.open to handle the parsing natively and drop the dataset payload.
-    # It automatically saves the references to `kerchunk_file`.
+    # It automatically saves the references to `virtualizarr_file`.
     xd = XarrayDriver()
     try:
-        xd.open(list(files), use_kerchunk=True, kerchunk_file=output, concat_dim=concat_dim)
+        xd.open(list(files), use_virtualizarr=True, virtualizarr_file=output, concat_dim=concat_dim)
         click.echo(f"Successfully generated {output}")
     except Exception as e:
-        click.echo(f"Error generating Kerchunk reference: {e}")
+        click.echo(f"Error generating VirtualiZarr reference: {e}")
 
 
 if __name__ == "__main__":

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -84,8 +84,8 @@ class XarrayDriver:
         self,
         files: Union[str, List[str]],
         use_dask: bool = False,
-        use_kerchunk: bool = False,
-        kerchunk_file: str = None,
+        use_virtualizarr: bool = False,
+        virtualizarr_file: str = None,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -97,11 +97,11 @@ class XarrayDriver:
             File path(s), URL(s), or glob pattern.
         use_dask : bool, optional
             Whether to use Dask for lazy loading, by default False.
-        use_kerchunk : bool, optional
-            Whether to use Kerchunk to create a virtual Zarr dataset, by default False.
+        use_virtualizarr : bool, optional
+            Whether to use VirtualiZarr to create a virtual Zarr dataset, by default False.
             Useful for large datasets to avoid xarray.open_mfdataset overhead.
-        kerchunk_file : str, optional
-            Path to save/load the Kerchunk reference JSON file. If provided and the file
+        virtualizarr_file : str, optional
+            Path to save/load the VirtualiZarr reference JSON file. If provided and the file
             exists, the references will be loaded from it. If the file does not exist,
             the references will be computed and saved to this path.
         **kwargs : dict
@@ -130,62 +130,83 @@ class XarrayDriver:
         preprocess = xr_kwargs.pop("preprocess", None)
         read_method = xr_kwargs.pop("read_method", None)
 
-        if use_kerchunk:
+        if use_virtualizarr:
             try:
                 import ujson  # noqa: F401
                 import zarr  # noqa: F401
-                from kerchunk.combine import MultiZarrToZarr
-                from kerchunk.hdf import SingleHdf5ToZarr
+                from obspec_utils.registry import ObjectStoreRegistry
+                from obstore.store import HTTPStore, LocalStore, S3Store
+                from virtualizarr import open_virtual_mfdataset
+                from virtualizarr.parsers import HDFParser
             except ImportError:
                 raise ImportError(
-                    "kerchunk requires 'kerchunk', 'ujson', and 'zarr'. "
-                    "Install with `pip install kerchunk ujson zarr`."
+                    "virtualizarr v2 requires 'virtualizarr', 'obstore', 'obspec_utils', 'ujson', and 'zarr'. "
+                    "Install with `pip install virtualizarr obstore obspec_utils ujson zarr`."
                 )
 
             import os
 
             refs = None
-            if kerchunk_file is not None and os.path.exists(kerchunk_file):
+            if virtualizarr_file is not None and os.path.exists(virtualizarr_file):
                 try:
-                    with open(kerchunk_file) as f_ref:
+                    with open(virtualizarr_file) as f_ref:
                         refs = ujson.load(f_ref)
                 except Exception as e:
                     import warnings
 
-                    warnings.warn(f"Failed to load kerchunk_file {kerchunk_file}: {e}")
+                    warnings.warn(f"Failed to load virtualizarr_file {virtualizarr_file}: {e}")
                     refs = None
 
             if refs is None:
-                dicts = []
-                for f in file_list:
-                    if f.startswith("s3://"):
-                        fs = fsspec.filesystem(
-                            "s3", anon=xr_kwargs.get("storage_options", {}).get("anon", True)
-                        )
-                    elif f.startswith("http://") or f.startswith("https://"):
-                        fs = fsspec.filesystem("http")
-                    else:
-                        fs = fsspec.filesystem("file")
+                registry = ObjectStoreRegistry()
 
-                    with fs.open(f, "rb") as infile:
-                        h5chunks = SingleHdf5ToZarr(infile, f)
-                        dicts.append(h5chunks.translate())
+                if file_list[0].startswith("s3://"):
+                    remote_options = dict(xr_kwargs.get("storage_options", {}))
+                    bucket_name = file_list[0].replace("s3://", "").split("/")[0]
+                    s3_config = {}
+                    if remote_options.get("anon", True):
+                        s3_config["skip_signature"] = "true"
+                    if "client_kwargs" in remote_options and "region_name" in remote_options["client_kwargs"]:
+                        s3_config["region"] = remote_options["client_kwargs"]["region_name"]
 
-                if len(dicts) == 1:
-                    refs = dicts[0]
+                    store = S3Store(bucket_name, config=s3_config)
+                    registry.register(f"s3://{bucket_name}", store)
+                elif file_list[0].startswith("http://") or file_list[0].startswith("https://"):
+                    store = HTTPStore()
+                    registry.register("http://", store)
+                    registry.register("https://", store)
                 else:
-                    concat_dim = xr_kwargs.get("concat_dim", "time")
-                    mzz = MultiZarrToZarr(dicts, concat_dims=[concat_dim])
-                    refs = mzz.translate()
+                    store = LocalStore(prefix="/")
+                    registry.register("file:///", store)
+                    file_list = [f"file://{f}" if not f.startswith("file://") else f for f in file_list]
 
-                if kerchunk_file is not None:
+                concat_dim = xr_kwargs.get("concat_dim", "time")
+                try:
+                    vds = open_virtual_mfdataset(
+                        file_list,
+                        registry=registry,
+                        parser=HDFParser(),
+                        combine="nested",
+                        concat_dim=concat_dim
+                    )
+                except ValueError:
+                    vds = open_virtual_mfdataset(
+                        file_list,
+                        registry=registry,
+                        parser=HDFParser(),
+                        combine="by_coords"
+                    )
+
+                refs = vds.vz.to_kerchunk()
+
+                if virtualizarr_file is not None:
                     try:
-                        with open(kerchunk_file, "w") as f_ref:
+                        with open(virtualizarr_file, "w") as f_ref:
                             ujson.dump(refs, f_ref)
                     except Exception as e:
                         import warnings
 
-                        warnings.warn(f"Failed to save kerchunk_file {kerchunk_file}: {e}")
+                        warnings.warn(f"Failed to save virtualizarr_file {virtualizarr_file}: {e}")
 
             remote_protocol = "file"
             remote_options = {}
@@ -196,6 +217,9 @@ class XarrayDriver:
                     remote_options["anon"] = True
             elif file_list[0].startswith("http"):
                 remote_protocol = "http"
+                # file_list for fsspec mapper should not start with file:// if they are local
+            elif file_list[0].startswith("file://"):
+                pass
 
             mapper = fsspec.get_mapper(
                 "reference://",

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -166,7 +166,10 @@ class XarrayDriver:
                     s3_config = {}
                     if remote_options.get("anon", True):
                         s3_config["skip_signature"] = "true"
-                    if "client_kwargs" in remote_options and "region_name" in remote_options["client_kwargs"]:
+                    if (
+                        "client_kwargs" in remote_options
+                        and "region_name" in remote_options["client_kwargs"]
+                    ):
                         s3_config["region"] = remote_options["client_kwargs"]["region_name"]
 
                     store = S3Store(bucket_name, config=s3_config)
@@ -178,7 +181,9 @@ class XarrayDriver:
                 else:
                     store = LocalStore(prefix="/")
                     registry.register("file:///", store)
-                    file_list = [f"file://{f}" if not f.startswith("file://") else f for f in file_list]
+                    file_list = [
+                        f"file://{f}" if not f.startswith("file://") else f for f in file_list
+                    ]
 
                 concat_dim = xr_kwargs.get("concat_dim", "time")
                 try:
@@ -187,14 +192,11 @@ class XarrayDriver:
                         registry=registry,
                         parser=HDFParser(),
                         combine="nested",
-                        concat_dim=concat_dim
+                        concat_dim=concat_dim,
                     )
                 except ValueError:
                     vds = open_virtual_mfdataset(
-                        file_list,
-                        registry=registry,
-                        parser=HDFParser(),
-                        combine="by_coords"
+                        file_list, registry=registry, parser=HDFParser(), combine="by_coords"
                     )
 
                 refs = vds.vz.to_kerchunk()


### PR DESCRIPTION
This PR updates the internal pre-computation cache mechanisms for large datasets from Kerchunk to VirtualiZarr v2.

In VirtualiZarr v2, `fsspec` mapper interfaces are replaced by rust-backed `obstore` instances which are passed through the `ObjectStoreRegistry` to `virtualizarr.open_virtual_mfdataset`. 

The `XarrayDriver` now supports `use_virtualizarr=True` and `virtualizarr_file="my_cache.json"`, which will generate the standard virtualized dataset via `to_kerchunk()` behind the scenes so the original `zarr` engine loader remains robust and performant.

Corresponding CLI commands have been updated (`monetio virtualizarr`), as well as the related markdown documentation.

---
*PR created automatically by Jules for task [15212108179679093789](https://jules.google.com/task/15212108179679093789) started by @bbakernoaa*