### PR TITLE
fix: standardize reader open_dataset signatures for monetio.load

### DIFF
--- a/monetio/readers/modis_ornl.py
+++ b/monetio/readers/modis_ornl.py
@@ -1,6 +1,6 @@
 """MODIS ORNL Reader"""
 
-from typing import Any, Optional, Union, List
+from typing import Any, List, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -124,7 +124,7 @@ def _nearest(items: pd.DatetimeIndex, pivot: pd.Timestamp) -> pd.Timestamp:
     Parameters
     ----------
     items : pd.DatetimeIndex
-        list of available dates.
+        List of available dates.
     pivot : pd.Timestamp
         Target date.
 

--- a/monetio/readers/modis_ornl.py
+++ b/monetio/readers/modis_ornl.py
@@ -27,7 +27,6 @@ class MODISORNLReader(GriddedReader):
 
     def open_dataset(
         self,
-        files: Union[str, List[str]] = None,
         date: Union[pd.Timestamp, str] = None,
         product: str = "MOD12A2H",
         band: str = "Lai_500m",
@@ -36,6 +35,7 @@ class MODISORNLReader(GriddedReader):
         longitude: float = 0,
         kmAboveBelow: int = 100,
         kmLeftRight: int = 100,
+        files: Union[str, List[str]] = None,
         **kwargs,
     ) -> xr.Dataset:
         """

--- a/monetio/readers/modis_ornl.py
+++ b/monetio/readers/modis_ornl.py
@@ -1,6 +1,6 @@
 """MODIS ORNL Reader"""
 
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, List
 
 import numpy as np
 import pandas as pd
@@ -27,7 +27,8 @@ class MODISORNLReader(GriddedReader):
 
     def open_dataset(
         self,
-        date: Union[pd.Timestamp, str],
+        files: Union[str, List[str]] = None,
+        date: Union[pd.Timestamp, str] = None,
         product: str = "MOD12A2H",
         band: str = "Lai_500m",
         quality_control: Optional[Any] = None,
@@ -123,7 +124,7 @@ def _nearest(items: pd.DatetimeIndex, pivot: pd.Timestamp) -> pd.Timestamp:
     Parameters
     ----------
     items : pd.DatetimeIndex
-        List of available dates.
+        list of available dates.
     pivot : pd.Timestamp
         Target date.
 

--- a/monetio/readers/nesdis_edr_viirs.py
+++ b/monetio/readers/nesdis_edr_viirs.py
@@ -2,7 +2,7 @@
 
 import datetime
 import os
-from typing import Union, List
+from typing import List, Union
 
 import numpy as np
 import pandas as pd

--- a/monetio/readers/nesdis_edr_viirs.py
+++ b/monetio/readers/nesdis_edr_viirs.py
@@ -24,11 +24,11 @@ class NESDISEDRVIIRSReader(GriddedReader):
 
     def open_dataset(
         self,
-        files: Union[str, List[str]] = None,
         date: Union[datetime.datetime, str, pd.Timestamp] = None,
         resolution: str = "high",
         datapath: str = ".",
         lazy: bool = False,
+        files: Union[str, List[str]] = None,
         **kwargs,
     ) -> xr.Dataset:
         """

--- a/monetio/readers/nesdis_edr_viirs.py
+++ b/monetio/readers/nesdis_edr_viirs.py
@@ -2,7 +2,7 @@
 
 import datetime
 import os
-from typing import Union
+from typing import Union, List
 
 import numpy as np
 import pandas as pd
@@ -24,7 +24,8 @@ class NESDISEDRVIIRSReader(GriddedReader):
 
     def open_dataset(
         self,
-        date: Union[datetime.datetime, str, pd.Timestamp],
+        files: Union[str, List[str]] = None,
+        date: Union[datetime.datetime, str, pd.Timestamp] = None,
         resolution: str = "high",
         datapath: str = ".",
         lazy: bool = False,

--- a/monetio/readers/nesdis_frp.py
+++ b/monetio/readers/nesdis_frp.py
@@ -87,7 +87,7 @@ class NESDISFRPReader(GriddedReader):
 
     def download_data(
         self, date: pd.Timestamp, ftype: str = "meanFRP", datapath: str = "."
-    ) -> list[str]:
+    ) -> List[str]:
         """
         Download NESDIS FRP data from the GSCE server.
 
@@ -102,8 +102,8 @@ class NESDISFRPReader(GriddedReader):
 
         Returns
         -------
-        list[str]
-            list of paths to the downloaded files.
+        List[str]
+            List of paths to the downloaded files.
         """
         yyyymmdd = date.strftime("%Y%m%d")
         url_ftype = f"&files={ftype}."

--- a/monetio/readers/nesdis_frp.py
+++ b/monetio/readers/nesdis_frp.py
@@ -23,7 +23,8 @@ class NESDISFRPReader(GriddedReader):
 
     def open_dataset(
         self,
-        date: Union[datetime.datetime, str, pd.Timestamp],
+        files: Union[str, List[str]] = None,
+        date: Union[datetime.datetime, str, pd.Timestamp] = None,
         ftype: str = "meanFRP",
         datapath: str = ".",
         lazy: bool = False,
@@ -86,7 +87,7 @@ class NESDISFRPReader(GriddedReader):
 
     def download_data(
         self, date: pd.Timestamp, ftype: str = "meanFRP", datapath: str = "."
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Download NESDIS FRP data from the GSCE server.
 
@@ -101,8 +102,8 @@ class NESDISFRPReader(GriddedReader):
 
         Returns
         -------
-        List[str]
-            List of paths to the downloaded files.
+        list[str]
+            list of paths to the downloaded files.
         """
         yyyymmdd = date.strftime("%Y%m%d")
         url_ftype = f"&files={ftype}."

--- a/monetio/readers/nesdis_frp.py
+++ b/monetio/readers/nesdis_frp.py
@@ -23,11 +23,11 @@ class NESDISFRPReader(GriddedReader):
 
     def open_dataset(
         self,
-        files: Union[str, List[str]] = None,
         date: Union[datetime.datetime, str, pd.Timestamp] = None,
         ftype: str = "meanFRP",
         datapath: str = ".",
         lazy: bool = False,
+        files: Union[str, List[str]] = None,
         **kwargs,
     ) -> xr.Dataset:
         """

--- a/monetio/readers/openaq_v2.py
+++ b/monetio/readers/openaq_v2.py
@@ -20,12 +20,12 @@ class OpenAQV2Reader(PointReader):
 
     def open_dataset(
         self,
-        files: Union[str, List[str]] = None,
         dates: Union[pd.DatetimeIndex, List[datetime.datetime], datetime.datetime, str] = None,
         parameters: List[str] = None,
         country: Union[str, List[str]] = None,
         sites: List[str] = None,
         wide_fmt: bool = True,
+        files: Union[str, List[str]] = None,
         **kwargs,
     ) -> Union[pd.DataFrame, "xr.Dataset"]:
         """

--- a/monetio/readers/openaq_v2.py
+++ b/monetio/readers/openaq_v2.py
@@ -33,13 +33,13 @@ class OpenAQV2Reader(PointReader):
 
         Parameters
         ----------
-        dates : Union[pd.DatetimeIndex, list[datetime.datetime], datetime.datetime, str]
+        dates : Union[pd.DatetimeIndex, List[datetime.datetime], datetime.datetime, str]
             Dates to retrieve.
-        parameters : list[str], optional
+        parameters : List[str], optional
             Species to retrieve, by default ['pm25', 'o3'].
-        country : Union[str, list[str]], optional
+        country : Union[str, List[str]], optional
             Country code(s).
-        sites : list[str], optional
+        sites : List[str], optional
             Site ID(s).
         wide_fmt : bool, optional
             Whether to return data in wide format, by default True.

--- a/monetio/readers/openaq_v2.py
+++ b/monetio/readers/openaq_v2.py
@@ -20,6 +20,7 @@ class OpenAQV2Reader(PointReader):
 
     def open_dataset(
         self,
+        files: Union[str, List[str]] = None,
         dates: Union[pd.DatetimeIndex, List[datetime.datetime], datetime.datetime, str] = None,
         parameters: List[str] = None,
         country: Union[str, List[str]] = None,
@@ -32,13 +33,13 @@ class OpenAQV2Reader(PointReader):
 
         Parameters
         ----------
-        dates : Union[pd.DatetimeIndex, List[datetime.datetime], datetime.datetime, str]
+        dates : Union[pd.DatetimeIndex, list[datetime.datetime], datetime.datetime, str]
             Dates to retrieve.
-        parameters : List[str], optional
+        parameters : list[str], optional
             Species to retrieve, by default ['pm25', 'o3'].
-        country : Union[str, List[str]], optional
+        country : Union[str, list[str]], optional
             Country code(s).
-        sites : List[str], optional
+        sites : list[str], optional
             Site ID(s).
         wide_fmt : bool, optional
             Whether to return data in wide format, by default True.


### PR DESCRIPTION
This resolves an issue where the unified `monetio.load()` entry point would crash with `TypeError: open_dataset() got an unexpected keyword argument 'files'` when invoking specific readers.

- Modified `monetio/readers/nesdis_edr_viirs.py`
- Modified `monetio/readers/nesdis_frp.py`
- Modified `monetio/readers/openaq_v2.py`
- Modified `monetio/readers/modis_ornl.py`

In each, `files: Union[str, List[str]] = None` was added to the `open_dataset` method signature. I also ensured the appropriate typing imports (`List`, `Union`) were present.

---
*PR created automatically by Jules for task [10074550819986047570](https://jules.google.com/task/10074550819986047570) started by @bbakernoaa*