### PR TITLE
Modernize MODIS ORNL Reader to Aero Protocol

### DIFF
--- a/monetio/readers/modis_ornl.py
+++ b/monetio/readers/modis_ornl.py
@@ -184,7 +184,9 @@ def _get_single_retrieval(
 
     # Parse data
     subset_data = data.subset[0].split(",")[5:]
-    grid_data = np.array([float(x) for x in subset_data]).reshape(metadata["nrows"], metadata["ncols"])
+    grid_data = np.array([float(x) for x in subset_data]).reshape(
+        metadata["nrows"], metadata["ncols"]
+    )
 
     # Apply scaling
     if metadata["scale"] != 1.0:

--- a/monetio/readers/modis_ornl.py
+++ b/monetio/readers/modis_ornl.py
@@ -58,11 +58,18 @@ class MODISORNLReader(GriddedReader):
             Kilometers above/below center.
         kmLeftRight : int, optional
             Kilometers left/right center.
+        **kwargs : dict
+            Additional arguments.
 
         Returns
         -------
         xr.Dataset
             The MODIS ORNL dataset.
+
+        Examples
+        --------
+        >>> reader = MODISORNLReader()
+        >>> ds = reader.open_dataset(date='2020-01-01', product='MOD15A2H', band='Lai_500m')
         """
         if not HAS_SUDS:
             raise ImportError(
@@ -70,7 +77,7 @@ class MODISORNLReader(GriddedReader):
             )
 
         date = pd.to_datetime(date)
-        m = _get_single_retrieval(
+        ds = _get_single_retrieval(
             date,
             product=product,
             band=band,
@@ -81,39 +88,10 @@ class MODISORNLReader(GriddedReader):
             kmLeftRight=kmLeftRight,
         )
 
-        ds = _make_xarray_dataset(m)
-
         # Update history
         ds = update_history(ds, f"Read MODIS ORNL {product} {band} data.")
 
         return ds
-
-
-class MODISData:
-    def __init__(self):
-        self.server = None
-        self.product = None
-        self.latitude = None
-        self.longitude = None
-        self.band = None
-        self.nrows = None
-        self.ncols = None
-        self.cellsize = None
-        self.scale = None
-        self.units = None
-        self.yllcorner = None
-        self.xllcorner = None
-        self.kmAboveBelow = 0
-        self.kmLeftRight = 0
-        self.dateStr = []
-        self.dateInt = []
-        self.data = []
-        self.isScaled = False
-
-    def applyScale(self):
-        if not self.isScaled:
-            self.data = self.data * self.scale
-            self.isScaled = True
 
 
 def _nearest(items: pd.DatetimeIndex, pivot: pd.Timestamp) -> pd.Timestamp:
@@ -144,9 +122,9 @@ def _get_single_retrieval(
     lon: float,
     kmAboveBelow: int,
     kmLeftRight: int,
-) -> MODISData:
+) -> xr.Dataset:
     """
-    Retrieve a single MODIS subset from ORNL.
+    Retrieve a single MODIS subset from ORNL and return as xr.Dataset.
 
     Parameters
     ----------
@@ -169,8 +147,8 @@ def _get_single_retrieval(
 
     Returns
     -------
-    MODISData
-        Object containing retrieved data and metadata.
+    xr.Dataset
+        Dataset containing retrieved data and metadata.
     """
     client = Client(DEFAULT_WSDL)
 
@@ -187,63 +165,78 @@ def _get_single_retrieval(
         lat, lon, product, band, date_str, date_str, kmAboveBelow, kmLeftRight
     )
 
-    m = MODISData()
-    m.server = DEFAULT_WSDL
-    m.product = product
-    m.band = band
-    m.latitude = lat
-    m.longitude = lon
-    m.nrows = int(data.nrows)
-    m.ncols = int(data.ncols)
-    m.cellsize = data.cellsize
-    m.scale = data.scale
-    m.units = data.units
-    m.yllcorner = data.yllcorner
-    m.xllcorner = data.xllcorner
-    m.dateInt = [int(target_date.strftime("%Y%j"))]
+    # Extract metadata
+    metadata = {
+        "server": DEFAULT_WSDL,
+        "product": product,
+        "band": band,
+        "latitude": lat,
+        "longitude": lon,
+        "nrows": int(data.nrows),
+        "ncols": int(data.ncols),
+        "cellsize": data.cellsize,
+        "scale": data.scale,
+        "units": data.units,
+        "yllcorner": data.yllcorner,
+        "xllcorner": data.xllcorner,
+        "date_int": int(target_date.strftime("%Y%j")),
+    }
 
     # Parse data
     subset_data = data.subset[0].split(",")[5:]
-    m.data = np.array([float(x) for x in subset_data]).reshape(1, -1)
+    grid_data = np.array([float(x) for x in subset_data]).reshape(metadata["nrows"], metadata["ncols"])
 
-    m.applyScale()
-    return m
+    # Apply scaling
+    if metadata["scale"] != 1.0:
+        grid_data = grid_data * metadata["scale"]
+
+    ds = _make_xarray_dataset(grid_data, metadata)
+
+    return ds
 
 
-def _make_xarray_dataset(m: MODISData) -> xr.Dataset:
+def _make_xarray_dataset(grid_data: np.ndarray, metadata: dict) -> xr.Dataset:
     """
-    Create an xarray Dataset from MODISData.
+    Create an xarray Dataset from raw data and metadata.
 
     Parameters
     ----------
-    m : MODISData
-        Object containing data and metadata.
+    grid_data : np.ndarray
+        2D grid data.
+    metadata : dict
+        Metadata dictionary.
 
     Returns
     -------
     xr.Dataset
         The formatted dataset.
     """
-    # Reshape and flip to match standard orientation if needed
-    # The original code did: m.data.reshape(m.ncols, m.nrows, order='C')[::-1, :]
-    # which resulted in (x, y) dims.
-    grid_data = m.data.reshape(m.nrows, m.ncols)
-
-    ds = xr.Dataset(
-        data_vars={m.band: (("y", "x"), grid_data)},
-        coords={"time": [pd.to_datetime(str(m.dateInt[0]), format="%Y%j")]},
-    )
+    band = metadata["band"]
+    # We use expand_dims later to add the time dimension to the data variables
+    ds = xr.Dataset(data_vars={band: (("y", "x"), grid_data)})
     ds = ds.expand_dims("time")
+    ds = ds.assign_coords({"time": [pd.to_datetime(str(metadata["date_int"]), format="%Y%j")]})
 
     # Add lat/lon
-    lon, lat = _get_latlon(m.xllcorner, m.yllcorner, m.cellsize, m.ncols, m.nrows)
+    lon, lat = _get_latlon(
+        metadata["xllcorner"],
+        metadata["yllcorner"],
+        metadata["cellsize"],
+        metadata["ncols"],
+        metadata["nrows"],
+    )
     ds = ds.assign_coords(
-        latitude=(("y", "x"), lat, {"units": "degrees_north", "standard_name": "latitude"}),
-        longitude=(("y", "x"), lon, {"units": "degrees_east", "standard_name": "longitude"}),
+        latitude=(("y", "x"), lat.data, {"units": "degrees_north", "standard_name": "latitude"}),
+        longitude=(("y", "x"), lon.data, {"units": "degrees_east", "standard_name": "longitude"}),
     )
 
-    ds[m.band].attrs.update({"units": m.units, "long_name": m.band, "product": m.product})
-    ds.attrs["server"] = m.server
+    ds[band].attrs.update(
+        {"units": metadata["units"], "long_name": band, "product": metadata["product"]}
+    )
+    ds.attrs["server"] = metadata["server"]
+
+    # Update history
+    ds = update_history(ds, "Created xarray Dataset from MODIS ORNL subset.")
 
     return ds
 

--- a/tests/test_aero_modis_ornl.py
+++ b/tests/test_aero_modis_ornl.py
@@ -1,6 +1,10 @@
 import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from unittest.mock import MagicMock, patch
 
-from monetio.readers.modis_ornl import _get_latlon
+from monetio.readers.modis_ornl import MODISORNLReader, _get_latlon, _make_xarray_dataset
 
 
 def test_modis_ornl_latlon_lazy():
@@ -19,12 +23,77 @@ def test_modis_ornl_latlon_lazy():
 
     # Check values (one point)
     # Sinusoidal projection at (0,0) should be (0,0)
-    # But note we have offsets and linspace
-    # x ranges from 0 to 10000, y from 0 to 8000
-    # Center should be roughly positive
     assert not np.isnan(lon.values).all()
     assert not np.isnan(lat.values).all()
 
     # Verify it can be chunked
     lon_lazy = lon.chunk({"x": 5, "y": 4})
     assert hasattr(lon_lazy.data, "dask")
+
+
+def test_make_xarray_dataset_eager_lazy():
+    """Verify _make_xarray_dataset works with eager and lazy data."""
+    metadata = {
+        "band": "test_band",
+        "date_int": 2020001,
+        "xllcorner": 0,
+        "yllcorner": 0,
+        "cellsize": 1000,
+        "ncols": 10,
+        "nrows": 8,
+        "units": "m",
+        "product": "MOD15A2H",
+        "server": "test_server",
+    }
+    grid_data = np.random.rand(8, 10)
+
+    # Eager
+    ds_eager = _make_xarray_dataset(grid_data, metadata)
+    assert isinstance(ds_eager["test_band"].data, np.ndarray)
+    assert ds_eager.test_band.shape == (1, 8, 10)
+    assert "history" in ds_eager.attrs
+
+    # Lazy
+    try:
+        import dask.array as da
+        grid_lazy = da.from_array(grid_data, chunks=(4, 5))
+        ds_lazy = _make_xarray_dataset(grid_lazy, metadata)
+        assert hasattr(ds_lazy["test_band"].data, "dask")
+
+        # Verify results match
+        xr.testing.assert_allclose(ds_eager, ds_lazy.compute())
+    except ImportError:
+        pytest.skip("Dask not installed")
+
+
+@patch("monetio.readers.modis_ornl.Client")
+def test_modis_ornl_reader_mock(mock_client):
+    """Test MODISORNLReader with mocked SOAP service."""
+    # Setup mock
+    instance = mock_client.return_value
+    instance.service.getdates.return_value = ["A2020001"]
+
+    mock_subset = MagicMock()
+    mock_subset.nrows = 8
+    mock_subset.ncols = 10
+    mock_subset.cellsize = 1000
+    mock_subset.scale = 0.1
+    mock_subset.units = "m"
+    mock_subset.yllcorner = 0
+    mock_subset.xllcorner = 0
+    # Data is comma-separated string, first 5 elements are metadata we skip
+    mock_subset.subset = ["0,0,0,0,0," + ",".join(["1.0"] * 80)]
+
+    instance.service.getsubset.return_value = mock_subset
+
+    reader = MODISORNLReader()
+    ds = reader.open_dataset(date="2020-01-01", product="MOD15A2H", band="Lai_500m")
+
+    assert isinstance(ds, xr.Dataset)
+    assert "Lai_500m" in ds.data_vars
+    assert ds.Lai_500m.shape == (1, 8, 10)
+    # Check scaling (1.0 * 0.1 = 0.1)
+    assert np.allclose(ds.Lai_500m.values, 0.1)
+    assert "history" in ds.attrs
+    assert "latitude" in ds.coords
+    assert "longitude" in ds.coords

--- a/tests/test_aero_modis_ornl.py
+++ b/tests/test_aero_modis_ornl.py
@@ -67,7 +67,10 @@ def test_make_xarray_dataset_eager_lazy():
         pytest.skip("Dask not installed")
 
 
-@patch("monetio.readers.modis_ornl.Client")
+@pytest.mark.skipif(
+    not pytest.importorskip("monetio.readers.modis_ornl").HAS_SUDS, reason="suds not installed"
+)
+@patch("monetio.readers.modis_ornl.Client", create=True)
 def test_modis_ornl_reader_mock(mock_client):
     """Test MODISORNLReader with mocked SOAP service."""
     # Setup mock

--- a/tests/test_aero_modis_ornl.py
+++ b/tests/test_aero_modis_ornl.py
@@ -1,8 +1,8 @@
+from unittest.mock import MagicMock, patch
+
 import numpy as np
-import pandas as pd
 import pytest
 import xarray as xr
-from unittest.mock import MagicMock, patch
 
 from monetio.readers.modis_ornl import MODISORNLReader, _get_latlon, _make_xarray_dataset
 
@@ -56,6 +56,7 @@ def test_make_xarray_dataset_eager_lazy():
     # Lazy
     try:
         import dask.array as da
+
         grid_lazy = da.from_array(grid_data, chunks=(4, 5))
         ds_lazy = _make_xarray_dataset(grid_lazy, metadata)
         assert hasattr(ds_lazy["test_band"].data, "dask")


### PR DESCRIPTION
This change refactors the `MODISORNLReader` in `monetio/readers/modis_ornl.py` to follow the Aero Protocol. It eliminates the non-standard `MODISData` class, streamlining the retrieval pipeline to work directly with Xarray Datasets. The update ensures the reader is backend-agnostic, properly documented with NumPy-style docstrings, and tracks data lineage through history attributes. A new test suite provides robust validation using mocked external services and dual-backend verification.

---
*PR created automatically by Jules for task [3225948400091756512](https://jules.google.com/task/3225948400091756512) started by @bbakernoaa*