### PR TITLE
Add Cubed backend support for gridded data loading

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@ We are moving to a unified reader system located in `monetio/readers/`.
 - **Maintainability**: Common logic (like S3 access, coordinate renaming, and lazy loading) is centralized in drivers and base classes.
 - **Lazy Loading**: Readers are registered and loaded only when needed, reducing initial import time.
 - **Performance (VirtualiZarr)**: For large gridded datasets (MERRA2, GFS, ICAP), readers leverage `use_virtualizarr=True` via the Xarray driver to bypass `open_mfdataset` overhead. By pre-computing references to `virtualizarr_file`, datasets map into memory virtually via the Zarr engine.
+- **Parallelism (Cubed)**: Experimental support for [Cubed](https://github.com/cubed-dev/cubed) as a lazy-loading backend is available via `use_cubed=True` in `monetio.load()` for gridded data sources. This requires `cubed` and `cubed-xarray` to be installed.
 
 
 ## Deprecation of Legacy Modules

--- a/docs/installing.md
+++ b/docs/installing.md
@@ -11,6 +11,15 @@
 - [s3fs](https://github.com/fsspec/s3fs)
 - [scipy](https://scipy.org/)
 
+## Optional Dependencies
+
+Some features require additional packages:
+
+- **Cubed backend**: `cubed` and `cubed-xarray`
+- **VirtualiZarr**: `virtualizarr`, `obstore`, `obspec_utils`, `ujson`, and `zarr`
+- **GRIB2 support**: `grib2io`
+- **HDF4 support**: `pyhdf`
+
 ## Instructions
 
 MONETIO is a pure Python package. The easiest way to install it is using `pip` or `conda`.

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -84,6 +84,7 @@ class XarrayDriver:
         self,
         files: Union[str, List[str]],
         use_dask: bool = False,
+        use_cubed: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str = None,
         **kwargs,
@@ -97,6 +98,8 @@ class XarrayDriver:
             File path(s), URL(s), or glob pattern.
         use_dask : bool, optional
             Whether to use Dask for lazy loading, by default False.
+        use_cubed : bool, optional
+            Whether to use Cubed for lazy loading, by default False.
         use_virtualizarr : bool, optional
             Whether to use VirtualiZarr to create a virtual Zarr dataset, by default False.
             Useful for large datasets to avoid xarray.open_mfdataset overhead.
@@ -112,18 +115,29 @@ class XarrayDriver:
         xr.Dataset
             The loaded dataset.
         """
-        # Expand wildcards (supports S3 globbing now)
-        file_list = FileUtility.expand_paths(files)
-
         # Prepare kwargs for xarray
         xr_kwargs = kwargs.copy()
+
+        if use_cubed:
+            try:
+                import cubed  # noqa: F401
+                import cubed_xarray  # noqa: F401
+            except ImportError:
+                raise ImportError(
+                    "The 'cubed' backend requires 'cubed' and 'cubed-xarray'. "
+                    "Install with `pip install cubed cubed-xarray`."
+                )
+            xr_kwargs["chunked_array_type"] = "cubed"
+
+        # Expand wildcards (supports S3 globbing now)
+        file_list = FileUtility.expand_paths(files)
 
         # Handle 'lazy' keyword: Eager by default per Aero Protocol.
         if "lazy" in xr_kwargs:
             use_dask = xr_kwargs.pop("lazy")
 
-        # If laziness or specific chunking is requested, ensure Dask auto-chunking is used.
-        if (use_dask or "chunks" in xr_kwargs) and "chunks" not in xr_kwargs:
+        # If laziness or specific chunking is requested, ensure auto-chunking is used.
+        if (use_dask or use_cubed or "chunks" in xr_kwargs) and "chunks" not in xr_kwargs:
             xr_kwargs["chunks"] = {}
 
         # Extract MONETIO-specific keywords

--- a/tests/test_aero_cubed.py
+++ b/tests/test_aero_cubed.py
@@ -1,8 +1,9 @@
-import os
 import numpy as np
 import pytest
 import xarray as xr
+
 from monetio.readers.drivers import XarrayDriver
+
 
 def test_cubed_backend(tmp_path):
     # 1. Create a mock NetCDF file
@@ -15,11 +16,8 @@ def test_cubed_backend(tmp_path):
     driver = XarrayDriver()
 
     # We need to make sure cubed and cubed-xarray are installed for this test
-    try:
-        import cubed
-        import cubed_xarray
-    except ImportError:
-        pytest.skip("cubed and cubed-xarray not installed")
+    pytest.importorskip("cubed")
+    pytest.importorskip("cubed_xarray")
 
     # Open with cubed
     ds = driver.open(str(fn), use_cubed=True, chunks={"x": 2, "y": 2})
@@ -33,14 +31,17 @@ def test_cubed_backend(tmp_path):
     assert hasattr(ds.foo.data, "__array_namespace__")
 
     import cubed.array_api.array_object
+
     assert isinstance(ds.foo.data, cubed.array_api.array_object.Array)
 
     # 4. Verify values
     np.testing.assert_allclose(ds.foo.values, data)
 
+
 def test_cubed_error_if_not_installed(monkeypatch):
     # Mock ImportError for cubed
     import builtins
+
     real_import = builtins.__import__
 
     def mock_import(name, *args, **kwargs):
@@ -51,5 +52,7 @@ def test_cubed_error_if_not_installed(monkeypatch):
     monkeypatch.setattr(builtins, "__import__", mock_import)
 
     driver = XarrayDriver()
-    with pytest.raises(ImportError, match="The 'cubed' backend requires 'cubed' and 'cubed-xarray'"):
+    with pytest.raises(
+        ImportError, match="The 'cubed' backend requires 'cubed' and 'cubed-xarray'"
+    ):
         driver.open("dummy.nc", use_cubed=True)

--- a/tests/test_aero_cubed.py
+++ b/tests/test_aero_cubed.py
@@ -1,0 +1,55 @@
+import os
+import numpy as np
+import pytest
+import xarray as xr
+from monetio.readers.drivers import XarrayDriver
+
+def test_cubed_backend(tmp_path):
+    # 1. Create a mock NetCDF file
+    fn = tmp_path / "test_cubed.nc"
+    data = np.random.rand(4, 4)
+    ds_orig = xr.Dataset({"foo": (("x", "y"), data)})
+    ds_orig.to_netcdf(fn)
+
+    # 2. Open using XarrayDriver with use_cubed=True
+    driver = XarrayDriver()
+
+    # We need to make sure cubed and cubed-xarray are installed for this test
+    try:
+        import cubed
+        import cubed_xarray
+    except ImportError:
+        pytest.skip("cubed and cubed-xarray not installed")
+
+    # Open with cubed
+    ds = driver.open(str(fn), use_cubed=True, chunks={"x": 2, "y": 2})
+
+    # 3. Verify it is a cubed-backed dataset
+    assert "foo" in ds.data_vars
+
+    # Check if the data is a cubed array.
+    # Cubed-xarray wraps the cubed array in an xarray-compatible object.
+    # We check the underlying data type.
+    assert hasattr(ds.foo.data, "__array_namespace__")
+
+    import cubed.array_api.array_object
+    assert isinstance(ds.foo.data, cubed.array_api.array_object.Array)
+
+    # 4. Verify values
+    np.testing.assert_allclose(ds.foo.values, data)
+
+def test_cubed_error_if_not_installed(monkeypatch):
+    # Mock ImportError for cubed
+    import builtins
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name in ["cubed", "cubed_xarray"]:
+            raise ImportError(f"No module named '{name}'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", mock_import)
+
+    driver = XarrayDriver()
+    with pytest.raises(ImportError, match="The 'cubed' backend requires 'cubed' and 'cubed-xarray'"):
+        driver.open("dummy.nc", use_cubed=True)


### PR DESCRIPTION
Add `use_cubed` support to `XarrayDriver` for gridded data loading.
Update documentation to reflect the new optional backend.
Add unit tests for the Cubed backend integration.
Remove stray binary file from root directory.

---
*PR created automatically by Jules for task [16474864044334245046](https://jules.google.com/task/16474864044334245046) started by @bbakernoaa*