### PR TITLE
Modernize NESDIS VIIRS JRR Reader

### DIFF
--- a/monetio/readers/nesdis_viirs_jrr.py
+++ b/monetio/readers/nesdis_viirs_jrr.py
@@ -1,13 +1,48 @@
 """NESDIS VIIRS JRR Reader"""
 
 import datetime
-from typing import List, Union
+from typing import List, Optional, Union
 
 import pandas as pd
 import xarray as xr
 
 from .base import GriddedReader, register_reader
 from .sat_utils import add_time_coord, standardize_satellite_coords, update_history
+
+JRR_SPECS = {
+    "AOD": {
+        "rename": {"AOD550": "aod_550"},
+        "metadata": {
+            "aod_550": {
+                "long_name": "Aerosol Optical Thickness at 550nm",
+                "units": "1",
+                "standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol",
+            }
+        },
+        "qa_var": "AOD_Quality_Flag",
+    },
+    "ADP": {
+        "rename": {},
+        "metadata": {
+            "Smoke": {
+                "long_name": "Aerosol Detection Product: Smoke",
+                "units": "1",
+                "standard_name": "is_smoke",
+            },
+            "Dust": {
+                "long_name": "Aerosol Detection Product: Dust",
+                "units": "1",
+                "standard_name": "is_dust",
+            },
+            "Ash": {
+                "long_name": "Aerosol Detection Product: Ash",
+                "units": "1",
+                "standard_name": "is_ash",
+            },
+        },
+        "qa_var": "ADP_Quality_Flag",
+    },
+}
 
 
 @register_reader("nesdis_viirs_jrr")
@@ -25,6 +60,7 @@ class VIIRSJRRReader(GriddedReader):
         dates: Union[pd.DatetimeIndex, List[datetime.datetime], datetime.datetime, str] = None,
         satellite: str = "snpp",
         product: str = "AOD",
+        qa_threshold: Optional[float] = None,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -41,6 +77,8 @@ class VIIRSJRRReader(GriddedReader):
             Default is 'snpp'.
         product : str, optional
             JRR product: 'AOD' (default), 'ADP', 'CloudMask', 'CloudHeight', etc.
+        qa_threshold : float, optional
+            Quality threshold for masking, by default None.
         **kwargs : dict
             Additional arguments passed to XarrayDriver.open.
 
@@ -57,7 +95,9 @@ class VIIRSJRRReader(GriddedReader):
         if "preprocess" not in kwargs:
             from functools import partial
 
-            kwargs["preprocess"] = partial(viirs_jrr_preprocess, product=product)
+            kwargs["preprocess"] = partial(
+                viirs_jrr_preprocess, product=product, qa_threshold=qa_threshold
+            )
 
         if "engine" not in kwargs:
             kwargs["engine"] = "h5netcdf"
@@ -129,7 +169,9 @@ class VIIRSJRRReader(GriddedReader):
         return sorted(urls)
 
 
-def viirs_jrr_preprocess(ds: xr.Dataset, product: str = "AOD") -> xr.Dataset:
+def viirs_jrr_preprocess(
+    ds: xr.Dataset, product: str = "AOD", qa_threshold: Optional[float] = None
+) -> xr.Dataset:
     """
     Preprocess VIIRS JRR dataset.
 
@@ -139,6 +181,8 @@ def viirs_jrr_preprocess(ds: xr.Dataset, product: str = "AOD") -> xr.Dataset:
         Input dataset.
     product : str, optional
         Product type, by default "AOD".
+    qa_threshold : float, optional
+        Quality threshold for masking, by default None.
 
     Returns
     -------
@@ -148,20 +192,32 @@ def viirs_jrr_preprocess(ds: xr.Dataset, product: str = "AOD") -> xr.Dataset:
     ds = standardize_satellite_coords(ds)
     ds = add_time_coord(ds, time_attr="time_coverage_start")
 
-    # Product-specific renaming
-    if product.upper() == "AOD":
-        if "AOD550" in ds.data_vars:
-            ds = ds.rename({"AOD550": "aod_550"})
-            ds["aod_550"].attrs.update(
-                {
-                    "long_name": "Aerosol Optical Thickness at 550nm",
-                    "units": "1",
-                    "standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol",
-                }
-            )
-    elif product.upper() == "ADP":
-        # ADP already has descriptive names like 'Smoke', 'Dust', 'Ash'
-        pass
+    spec = JRR_SPECS.get(product.upper(), {})
+
+    # 1. Product-specific renaming
+    rename_dict = {k: v for k, v in spec.get("rename", {}).items() if k in ds.data_vars}
+    if rename_dict:
+        ds = ds.rename(rename_dict)
+
+    # 2. Attribute assignment
+    for var, attrs in spec.get("metadata", {}).items():
+        if var in ds.data_vars:
+            ds[var].attrs.update(attrs)
+
+    # 3. Quality Flagging (Lazy & Vectorized)
+    qa_var = spec.get("qa_var")
+    if qa_threshold is not None and qa_var in ds.variables:
+        # Mask data variables where quality is below threshold
+        # We assume higher is better or use exact match for bitmasks if needed.
+        # For JRR, we use >= threshold logic similar to TROPOMI/MODIS.
+        mask = ds[qa_var] >= qa_threshold
+        # Keep qa_var and coords, mask data_vars
+        qa = ds[qa_var].copy()
+        ds = ds.where(mask)
+        ds[qa_var] = qa
+
+    # Update history
+    ds = update_history(ds, f"Preprocessed NESDIS VIIRS JRR {product} data.")
 
     return ds
 

--- a/tests/test_aero_viirs_jrr.py
+++ b/tests/test_aero_viirs_jrr.py
@@ -31,8 +31,63 @@ def test_viirs_jrr_preprocess(product):
 
     if product == "AOD":
         assert "aod_550" in ds_out.data_vars
+        assert ds_out["aod_550"].attrs["units"] == "1"
     elif product == "ADP":
         assert "Smoke" in ds_out.data_vars
+        assert "long_name" in ds_out["Smoke"].attrs
+
+
+def test_viirs_jrr_preprocess_qa():
+    # Test quality masking
+    ds = xr.Dataset(
+        {
+            "AOD550": (("Rows", "Columns"), [[1.0, 2.0], [3.0, 4.0]]),
+            "AOD_Quality_Flag": (("Rows", "Columns"), [[0, 1], [2, 3]]),
+            "Latitude": (("Rows", "Columns"), np.zeros((2, 2))),
+            "Longitude": (("Rows", "Columns"), np.zeros((2, 2))),
+        },
+        attrs={"time_coverage_start": "2024-01-01T00:00:00Z"},
+    )
+
+    # Mask with threshold 2 (should keep 3.0 and 4.0)
+    ds_out = viirs_jrr_preprocess(ds, product="AOD", qa_threshold=2)
+
+    assert "aod_550" in ds_out.data_vars
+    # Use .item() or flat access for 0D/1D checks to be safe, but here they are 2D
+    assert np.isnan(ds_out.aod_550.values.flatten()[0])
+    assert np.isnan(ds_out.aod_550.values.flatten()[1])
+    assert ds_out.aod_550.values.flatten()[2] == 3.0
+    assert ds_out.aod_550.values.flatten()[3] == 4.0
+    # Quality flag itself should remain unmasked
+    assert ds_out.AOD_Quality_Flag.values.flatten()[0] == 0
+
+
+def test_viirs_jrr_eager_lazy_consistency():
+    import dask.array as da
+
+    # Create dummy dataset
+    data = np.random.rand(10, 10)
+    qa = np.random.randint(0, 4, (10, 10))
+
+    ds_eager = xr.Dataset(
+        {
+            "AOD550": (("y", "x"), data),
+            "AOD_Quality_Flag": (("y", "x"), qa),
+            "Latitude": (("y", "x"), np.zeros((10, 10))),
+            "Longitude": (("y", "x"), np.zeros((10, 10))),
+        },
+        attrs={"time_coverage_start": "2024-01-01T00:00:00Z"},
+    )
+
+    ds_lazy = ds_eager.chunk({"y": 5, "x": 5})
+
+    # Run preprocess
+    out_eager = viirs_jrr_preprocess(ds_eager, product="AOD", qa_threshold=2)
+    out_lazy = viirs_jrr_preprocess(ds_lazy, product="AOD", qa_threshold=2)
+
+    # Check consistency
+    xr.testing.assert_allclose(out_eager, out_lazy.compute())
+    assert isinstance(out_lazy.aod_550.data, da.Array)
 
 
 def test_viirs_jrr_build_urls(monkeypatch):


### PR DESCRIPTION
Modernized the NESDIS VIIRS JRR reader to follow the Aero Protocol. Key changes include:
1.  **Metadata Centralization**: Added `JRR_SPECS` to manage product-specific renaming and attributes for AOD and ADP.
2.  **Lazy Quality Masking**: Implemented vectorized masking using `ds.where()` in `viirs_jrr_preprocess`, allowing users to filter by quality flags lazily.
3.  **Aero Protocol Compliance**: Removed hardcoded logic, ensured no hidden computes, and added provenance tracking via `update_history`.
4.  **Robust Testing**: Updated `tests/test_aero_viirs_jrr.py` to verify consistency between NumPy and Dask backends and validate the new masking logic.

---
*PR created automatically by Jules for task [1695867587360751690](https://jules.google.com/task/1695867587360751690) started by @bbakernoaa*