### PR TITLE
Modernize readers for Aero Protocol compliance

### DIFF
--- a/monetio/readers/aeronet.py
+++ b/monetio/readers/aeronet.py
@@ -199,7 +199,7 @@ class AERONETReader(PointReader):
             try:
                 import dask.dataframe as dd
 
-                if isinstance(df, dd.DataFrame):
+                if isinstance(df, dd.DataFrame) and not isinstance(df, pd.DataFrame):
                     df = df.compute(num_workers=n_procs)
             except ImportError:
                 pass
@@ -737,13 +737,14 @@ def read_aeronet_csv(
     return df.copy()
 
 
-def _dust_detect(df: pd.DataFrame) -> pd.DataFrame:
+def _dust_detect(df: Union[pd.DataFrame, "dd.DataFrame"]) -> Union[pd.DataFrame, "dd.DataFrame"]:
     """Detect dust based on AOD and Angstrom exponent."""
     if "aod_1020nm" in df.columns and "440-870_angstrom_exponent" in df.columns:
         df["dust"] = (df["aod_1020nm"] > 0.3) & (df["440-870_angstrom_exponent"] < 0.6)
     elif "dust" not in df.columns:
         # Ensure 'dust' column exists for Dask metadata consistency
-        df["dust"] = np.array([False] * len(df), dtype=bool)
+        # We use a vectorized assignment that works for both Pandas and Dask
+        df["dust"] = False
 
     # Consistently use object or boolean dtype to support NaNs if needed,
     # but here we'll stick to bool/object consistency for Dask

--- a/monetio/readers/airnow.py
+++ b/monetio/readers/airnow.py
@@ -108,7 +108,7 @@ class AirNowReader(PointReader):
 
         df = self.harmonize(df)
 
-        if not lazy and hasattr(df, "compute"):
+        if not lazy and hasattr(df, "compute") and not isinstance(df, pd.DataFrame):
             df = df.compute(num_workers=n_procs)
 
         if as_xarray:
@@ -152,6 +152,13 @@ class AirNowReader(PointReader):
             # Only fix if current_uo is 0 and longitude is far from 0
             # We use a vectorized approach
             mask = (current_uo == 0) & (np.abs(lon) > 20)
+            # Use sum() or other dask-friendly reduction if we really wanted to check,
+            # but in apply_ufunc we can just process it.
+            # To avoid hidden compute from np.any(mask) if current_uo is dask,
+            # we should avoid it. But here we are inside the worker function,
+            # so mask is already a numpy array.
+            # WAIT: if dask="parallelized", then _get_uo_vec is called on numpy chunks.
+            # So np.any(mask) is fine here!
             if not np.any(mask):
                 return current_uo
 
@@ -522,7 +529,7 @@ def filter_bad_values(
 
                 # Merge back to bad_rows
                 bad_rows_fixed = bad_rows.merge(mapping, on=["latitude", "longitude"], how="left")
-                df.loc[bad_rows.index, "utcoffset"] = bad_rows_fixed.new_offset.values
+                df.loc[bad_rows.index, "utcoffset"] = bad_rows_fixed.new_offset.to_numpy()
         elif bad_utcoffset == "leave":
             pass
         else:

--- a/monetio/readers/aqs.py
+++ b/monetio/readers/aqs.py
@@ -130,8 +130,9 @@ class AQSReader(PointReader):
         if is_dask:
             if df.npartitions == 0:
                 return df
-        elif len(df) == 0:
-            return df
+        else:
+            if df.empty:
+                return df
 
         # Filter dates
         if dates is not None:
@@ -146,7 +147,7 @@ class AQSReader(PointReader):
         df = self.harmonize(df)
 
         # Handle eager compute for Dask-backed objects if requested
-        if not lazy and is_dask:
+        if not lazy and is_dask and not isinstance(df, pd.DataFrame):
             df = df.compute(num_workers=n_procs)
 
         if as_xarray:

--- a/monetio/readers/hysplit.py
+++ b/monetio/readers/hysplit.py
@@ -1,52 +1,79 @@
 """HYSPLIT Reader"""
 
 import datetime
+from typing import Any
 
 import numpy as np
 import pandas as pd
 import xarray as xr
 
-from .base import GriddedReader, register_reader
+from .base import GriddedReader, register_reader, update_history
 from .drivers import FileUtility
-from .sat_utils import update_history
 
 
 @register_reader("hysplit")
 class HYSPLITReader(GriddedReader):
     def open_dataset(
         self,
-        files,
-        drange=None,
-        century=None,
-        verbose=False,
-        sample_time_stamp="start",
-        check_grid=True,
-        **kwargs,
-    ):
+        files: str | list[str],
+        drange: list[datetime.datetime] | None = None,
+        century: int | None = None,
+        verbose: bool = False,
+        sample_time_stamp: str = "start",
+        check_grid: bool = True,
+        lazy: bool = False,
+        **kwargs: Any,
+    ) -> xr.Dataset:
         """
         Reads HYSPLIT binary concentration (cdump) files.
-        """
-        file_list = FileUtility.expand_paths(files)
 
-        if len(file_list) == 1:
-            ds = open_dataset_hysplit(
-                file_list[0],
-                drange=drange,
-                century=century,
-                verbose=verbose,
-                sample_time_stamp=sample_time_stamp,
-                check_grid=check_grid,
-            )
-        else:
-            blist = [(f, f, "met") for f in file_list]
-            ds = combine_dataset(
-                blist,
-                drange=drange,
-                century=century,
-                verbose=verbose,
-                sample_time_stamp=sample_time_stamp,
-                check_grid=check_grid,
-            )
+        Parameters
+        ----------
+        files : Union[str, List[str]]
+            File path(s), URL(s), or glob pattern.
+        drange : List[datetime.datetime], optional
+            Date range to filter, by default None.
+        century : int, optional
+            Century to use for 2-digit years (e.g. 2000), by default None.
+        verbose : bool, optional
+            Whether to print verbose output, by default False.
+        sample_time_stamp : str, optional
+            Time stamp to use ('start' or 'end'), by default "start".
+        check_grid : bool, optional
+            Whether to fix grid continuity, by default True.
+        lazy : bool, optional
+            Whether to use Dask for lazy loading, by default False.
+        **kwargs : Any
+            Additional arguments passed to the driver.
+
+        Returns
+        -------
+        xr.Dataset
+            The processed HYSPLIT dataset.
+        """
+        # Set up kwargs for read_method
+        read_kwargs = {
+            "drange": drange,
+            "century": century,
+            "verbose": verbose,
+            "sample_time_stamp": sample_time_stamp,
+            "check_grid": check_grid,
+        }
+
+        # If it is a single file, we can use open_dataset_hysplit directly
+        # If it is multiple files, we use combine_dataset which we'll modernize
+        # but better yet, let's use the XarrayDriver with our custom logic.
+
+        # We override the driver.open call to support our specific multi-file logic
+        # while still benefiting from FileUtility and potential future driver features.
+        ds = self.driver.open(
+            files,
+            read_method=open_dataset_hysplit,
+            lazy=lazy,
+            preprocess=None,  # HYSPLIT handles its own preprocessing
+            **read_kwargs,
+            **kwargs,
+        )
 
         ds = update_history(ds, "Read HYSPLIT data.")
         return ds
@@ -294,7 +321,10 @@ class ModelBin:
         concframe["levels"] = lev_name
         concframe["time"] = pdate1
 
-        names = concframe.columns.values
+        # Use list() to avoid .values compute if this were a Series/Index,
+        # but here it's a NumPy array from columns anyway.
+        # Still, let's make it cleaner.
+        names = list(concframe.columns)
         names = ["y" if x == "jndx" else x for x in names]
         names = ["x" if x == "indx" else x for x in names]
         names = ["z" if x == "levels" else x for x in names]

--- a/monetio/readers/ndbc.py
+++ b/monetio/readers/ndbc.py
@@ -81,7 +81,7 @@ class NDBCReader(PointReader):
         df = self._post_process(df)
         df = self.harmonize(df)
 
-        if not lazy and hasattr(df, "compute"):
+        if not lazy and hasattr(df, "compute") and not isinstance(df, pd.DataFrame):
             df = df.compute(num_workers=n_procs)
 
         if as_xarray:

--- a/monetio/readers/openaq.py
+++ b/monetio/readers/openaq.py
@@ -121,7 +121,7 @@ class OpenAQReader(PointReader):
         df = self._post_process(df, dates=dates, wide_fmt=do_wide, n_procs=n_procs)
         df = self.harmonize(df)
 
-        if not lazy and hasattr(df, "compute"):
+        if not lazy and hasattr(df, "compute") and not isinstance(df, pd.DataFrame):
             df = df.compute(num_workers=n_procs)
 
         if as_xarray:

--- a/monetio/readers/pams.py
+++ b/monetio/readers/pams.py
@@ -97,12 +97,16 @@ class PAMSReader(PointReader):
 
             if "obs" in ds.data_vars and "units" not in ds["obs"].attrs:
                 # Fallback for non-pivoted or if mapping failed
-                if "units" in ds.variables and not hasattr(ds["units"].data, "dask"):
+                if "units" in ds.variables:
                     try:
                         # Extract units from the first element of 'units' coordinate/variable
                         # This works if 'units' is a string array/coordinate
-                        unit_val = str(ds["units"].values[0])
-                        ds["obs"].attrs["units"] = unit_val
+                        if hasattr(ds["units"].data, "dask"):
+                            # Use delayed or just skip if dask to avoid compute
+                            pass
+                        else:
+                            unit_val = str(ds["units"].to_numpy()[0])
+                            ds["obs"].attrs["units"] = unit_val
                     except (IndexError, AttributeError, KeyError):
                         pass
 


### PR DESCRIPTION
Improved several monetio readers (HYSPLIT, AirNow, AQS, PAMS, NDBC, and AERONET) to better adhere to the Aero Protocol by ensuring backend-agnostic behavior and maintaining laziness. Key changes include modernizing HYSPLITReader to support lazy loading via XarrayDriver, guarding .compute() calls, and replacing eager .values or len(df) calls with lazy-friendly alternatives.

---
*PR created automatically by Jules for task [17193191972796471097](https://jules.google.com/task/17193191972796471097) started by @bbakernoaa*