### PR TITLE
Refactor Scientific Hygiene and WRF-Chem Time Parsing

### DIFF
--- a/monetio/readers/base.py
+++ b/monetio/readers/base.py
@@ -690,3 +690,48 @@ def _get_ioapi_times(ds: xr.Dataset) -> xr.Dataset:
     ds = update_history(ds, "Optimized IOAPI time parsing.")
 
     return ds
+
+
+def _scientific_hygiene(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Apply standard scientific hygiene to the dataset.
+
+    1. Identifies standard coordinates (latitude, longitude, time) and ensures they are set.
+    2. Strips whitespace from all string attributes.
+    3. Updates the history attribute.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Input dataset.
+
+    Returns
+    -------
+    xarray.Dataset
+        Processed dataset.
+    """
+    # 1. Coordinate Handling - Ensure standard coordinates are set
+    # We do NOT use reset_coords() to avoid demoting non-standard coords.
+    coords = [
+        c for c in ["latitude", "longitude", "time"] if c in ds.variables and c not in ds.coords
+    ]
+    if coords:
+        ds = ds.set_coords(coords)
+
+    # 2. Attribute Cleaning - Strip whitespace from string attributes
+    for var in ds.variables:
+        for attr, val in ds[var].attrs.items():
+            if isinstance(val, str):
+                ds[var].attrs[attr] = val.strip()
+
+    # Also for global attributes
+    for attr, val in ds.attrs.items():
+        if isinstance(val, str):
+            ds.attrs[attr] = val.strip()
+
+    # 3. Provenance tracking
+    ds = update_history(
+        ds, "Applied scientific hygiene (standard coordinates and attribute cleaning)."
+    )
+
+    return ds

--- a/monetio/readers/camx.py
+++ b/monetio/readers/camx.py
@@ -12,6 +12,7 @@ from .base import (
     _add_ioapi_latlon,
     _convert_to_ppb,
     _format_units,
+    _scientific_hygiene,
     add_lazy_diagnostic,
     register_reader,
 )
@@ -155,11 +156,8 @@ def camx_preprocess(
     # 6. Predefined mapping tables (backward compatibility)
     ds = _predefined_mapping_tables(ds)
 
-    # 7. Scientific Hygiene: Strip whitespace from all string attributes
-    for var in ds.variables:
-        for attr, val in ds[var].attrs.items():
-            if isinstance(val, str):
-                ds[var].attrs[attr] = val.strip()
+    # 7. Scientific Hygiene
+    ds = _scientific_hygiene(ds)
 
     # Update history
     ds = update_history(ds, "Preprocessed CAMx data.")

--- a/monetio/readers/chimere.py
+++ b/monetio/readers/chimere.py
@@ -5,7 +5,7 @@ from typing import Any
 
 import xarray as xr
 
-from .base import GriddedReader, register_reader
+from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import update_history
 
 
@@ -121,11 +121,8 @@ def chimere_preprocess(
     if dims:
         ds = ds.transpose(*dims)
 
-    # Scientific Hygiene: Strip whitespace from all string attributes
-    for var in ds.variables:
-        for attr, val in ds[var].attrs.items():
-            if isinstance(val, str):
-                ds[var].attrs[attr] = val.strip()
+    # Scientific Hygiene
+    ds = _scientific_hygiene(ds)
 
     # Update history
     ds = update_history(ds, "Preprocessed Chimere data.")

--- a/monetio/readers/cmaq.py
+++ b/monetio/readers/cmaq.py
@@ -12,6 +12,7 @@ from .base import (
     _add_ioapi_latlon,
     _convert_to_ppb,
     _format_units,
+    _scientific_hygiene,
     add_lazy_diagnostic,
     register_reader,
 )
@@ -166,11 +167,8 @@ def cmaq_preprocess(
     if rename_dict:
         ds = ds.rename(rename_dict)
 
-    # 6. Scientific Hygiene: Strip whitespace from all string attributes
-    for var in ds.variables:
-        for attr, val in ds[var].attrs.items():
-            if isinstance(val, str):
-                ds[var].attrs[attr] = val.strip()
+    # 6. Scientific Hygiene
+    ds = _scientific_hygiene(ds)
 
     # Update history
     ds = update_history(ds, "Preprocessed CMAQ data.")

--- a/monetio/readers/merra2.py
+++ b/monetio/readers/merra2.py
@@ -5,7 +5,7 @@ import datetime
 import pandas as pd
 import xarray as xr
 
-from .base import GriddedReader, register_reader
+from .base import GriddedReader, _scientific_hygiene, register_reader
 from .nasa_utils import setup_netrc
 from .sat_utils import standardize_satellite_coords, update_history
 
@@ -237,6 +237,9 @@ def merra2_preprocess(ds: xr.Dataset, product: str | None = None) -> xr.Dataset:
 
     # 4. Calculate Pressure (Lazy)
     ds = _add_merra2_pressure(ds)
+
+    # 5. Scientific Hygiene
+    ds = _scientific_hygiene(ds)
 
     # Update history
     ds = update_history(ds, "Preprocessed MERRA-2 data via Aero Protocol.")

--- a/monetio/readers/rrfs.py
+++ b/monetio/readers/rrfs.py
@@ -6,7 +6,7 @@ from typing import Any
 import pandas as pd
 import xarray as xr
 
-from .base import _format_units, register_reader
+from .base import _format_units, _scientific_hygiene, register_reader
 from .gfs import NCEPPDSReader
 from .sat_utils import update_history
 
@@ -184,11 +184,8 @@ def rrfs_preprocess(ds: xr.Dataset) -> xr.Dataset:
     # 1. Format Units
     ds = _format_units(ds)
 
-    # 2. Scientific Hygiene: Strip whitespace from all string attributes
-    for var in ds.variables:
-        for attr, val in ds[var].attrs.items():
-            if isinstance(val, str):
-                ds[var].attrs[attr] = val.strip()
+    # 2. Scientific Hygiene
+    ds = _scientific_hygiene(ds)
 
     # Update history
     ds = update_history(ds, "Preprocessed RRFS data.")

--- a/monetio/readers/ufs.py
+++ b/monetio/readers/ufs.py
@@ -9,6 +9,7 @@ from .base import (
     GriddedReader,
     _convert_to_ppb,
     _convert_ugkg_to_ugm3,
+    _scientific_hygiene,
     add_lazy_diagnostic,
     register_reader,
 )
@@ -169,10 +170,7 @@ class UFSReader(GriddedReader):
             ds = ds[available]
 
         # Scientific Hygiene
-        for var in ds.variables:
-            for attr, val in ds[var].attrs.items():
-                if isinstance(val, str):
-                    ds[var].attrs[attr] = val.strip()
+        ds = _scientific_hygiene(ds)
 
         # Update history
         ds = update_history(ds, "Read UFS-AQM data.")

--- a/monetio/readers/wrfchem.py
+++ b/monetio/readers/wrfchem.py
@@ -10,6 +10,7 @@ from .base import (
     GriddedReader,
     _convert_to_ppb,
     _convert_ugkg_to_ugm3,
+    _scientific_hygiene,
     add_lazy_diagnostic,
     register_reader,
 )
@@ -169,15 +170,7 @@ def wrfchem_preprocess(
         ds = ds.isel(z=[0])
 
     # 7. Scientific Hygiene
-    ds = ds.reset_coords()
-    coords = [c for c in ["latitude", "longitude", "time"] if c in ds.variables]
-    ds = ds.set_coords(coords)
-
-    # Strip whitespace from string attributes
-    for var in ds.variables:
-        for attr, val in ds[var].attrs.items():
-            if isinstance(val, str):
-                ds[var].attrs[attr] = val.strip()
+    ds = _scientific_hygiene(ds)
 
     # Update history
     ds = update_history(ds, "Preprocessed WRF-Chem data.")
@@ -198,18 +191,23 @@ def _parse_wrf_times(ds: xr.Dataset) -> xr.Dataset:
     -------
     xarray.Dataset
         Dataset with 'time' coordinate.
+
+    Examples
+    --------
+    >>> ds = _parse_wrf_times(ds)
     """
     times_var = ds.Times
 
-    # Find the string dimension
-    string_dim = [d for d in times_var.dims if d != "time"]
-    if not string_dim:
+    # Find the string dimension (usually 'DateStrLen')
+    # We expect 'time' to be the other dimension if it's 2D
+    string_dims = [d for d in times_var.dims if d != "time"]
+    if not string_dims:
         if times_var.ndim == 1:
-            string_dim = [times_var.dims[0]]
+            string_dim = times_var.dims[0]
         else:
             return ds
-
-    string_dim = string_dim[-1]
+    else:
+        string_dim = string_dims[-1]
 
     # Use vectorized parser from time_utils
     parsed_times = xr.apply_ufunc(
@@ -222,13 +220,12 @@ def _parse_wrf_times(ds: xr.Dataset) -> xr.Dataset:
         output_dtypes=[np.dtype("datetime64[ns]")],
     )
 
-    # Force the name and dims of parsed_times to be 'time' if it was batch-dimensioned by it
-    if "time" in parsed_times.dims:
-        parsed_times = parsed_times.rename("time")
+    # Standardize name
+    parsed_times = parsed_times.rename("time")
 
-    # If 'time' dimension already exists, update it
+    # Assign coordinate
     if "time" in ds.dims:
-        ds.coords["time"] = parsed_times
+        ds = ds.assign_coords(time=parsed_times)
     else:
         ds["time"] = parsed_times
 

--- a/tests/test_aero_hygiene.py
+++ b/tests/test_aero_hygiene.py
@@ -1,0 +1,75 @@
+import numpy as np
+import pytest
+import xarray as xr
+
+from monetio.readers.base import _scientific_hygiene
+
+
+def create_test_ds():
+    """Create a test dataset for hygiene checks."""
+    ds = xr.Dataset(
+        data_vars={
+            "O3": (
+                ("time", "y", "x"),
+                np.ones((2, 3, 3)),
+                {"units": " ppb ", "long_name": " Ozone "},
+            ),
+            "latitude": (("y", "x"), np.zeros((3, 3)), {"units": "degrees_north"}),
+            "longitude": (("y", "x"), np.zeros((3, 3)), {"units": "degrees_east"}),
+        },
+        coords={
+            "time": (("time",), [0, 1], {"units": "hours since 2023-01-01"}),
+            "z": (("z",), [0, 1, 2], {"units": "m"}),
+        },
+        attrs={"project": " MONETIO ", "history": "Created."},
+    )
+    return ds
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_scientific_hygiene_logic(lazy):
+    """Test _scientific_hygiene with Eager and Lazy backends."""
+    ds = create_test_ds()
+    if lazy:
+        ds = ds.chunk({"time": 1})
+
+    ds_clean = _scientific_hygiene(ds)
+
+    # 1. Verify Standard Coordinates are set
+    assert "latitude" in ds_clean.coords
+    assert "longitude" in ds_clean.coords
+    assert "time" in ds_clean.coords
+
+    # 2. Verify Non-Standard Coordinates are PRESERVED
+    # 'z' was already a coord, it should stay one
+    assert "z" in ds_clean.coords
+
+    # 3. Verify Whitespace Stripping
+    assert ds_clean.O3.attrs["units"] == "ppb"
+    assert ds_clean.O3.attrs["long_name"] == "Ozone"
+    assert ds_clean.attrs["project"] == "MONETIO"
+
+    # 4. Verify History Update
+    assert "Applied scientific hygiene" in ds_clean.attrs["history"]
+    assert ds_clean.attrs["history"].startswith("Created.")
+
+    # 5. Verify Backend preservation
+    if lazy:
+        assert ds_clean.O3.chunks is not None
+    else:
+        assert ds_clean.O3.chunks is None
+
+
+def test_scientific_hygiene_consistency():
+    """Explicitly verify Eager/Lazy consistency for hygiene."""
+    ds_eager = create_test_ds()
+    ds_lazy = ds_eager.chunk({"time": 1})
+
+    res_eager = _scientific_hygiene(ds_eager)
+    res_lazy = _scientific_hygiene(ds_lazy).compute()
+
+    xr.testing.assert_allclose(res_eager, res_lazy)
+    # Check attributes specifically since assert_allclose might skip them depending on options
+    assert res_eager.attrs == res_lazy.attrs
+    for var in res_eager.data_vars:
+        assert res_eager[var].attrs == res_lazy[var].attrs


### PR DESCRIPTION
This PR modernizes the "Scientific Hygiene" process across gridded readers by centralizing it in `monetio/readers/base.py`. This reduces boilerplate and ensures consistent metadata cleaning (stripping whitespace from string attributes) and standard coordinate handling without demoting non-standard coordinates like vertical levels.

The WRF-Chem reader was specifically updated to use this utility and its time parsing logic was refactored to be more robust and fully support lazy Dask-backed datasets by using `dask='parallelized'` in `xr.apply_ufunc`.

A new test file `tests/test_aero_hygiene.py` was added to verify these changes across both Eager (NumPy) and Lazy (Dask) backends, as required by the Aero Protocol.

---
*PR created automatically by Jules for task [13887763627864814408](https://jules.google.com/task/13887763627864814408) started by @bbakernoaa*