### PR TITLE
Modernize NESDIS EPS VIIRS reader to follow Aero Protocol

### DIFF
--- a/monetio/readers/nesdis_eps_viirs.py
+++ b/monetio/readers/nesdis_eps_viirs.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 
-from .base import GriddedReader, register_reader
+from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import add_time_coord, standardize_satellite_coords, update_history
 
 
@@ -19,8 +19,8 @@ class NESDISEPSVIIRSReader(GriddedReader):
 
     def open_dataset(
         self,
-        files: str | list[str] = None,
-        dates: pd.DatetimeIndex | list[datetime.datetime] | datetime.datetime | str = None,
+        files: str | list[str] | None = None,
+        dates: pd.DatetimeIndex | list[datetime.datetime] | datetime.datetime | str | None = None,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -28,9 +28,9 @@ class NESDISEPSVIIRSReader(GriddedReader):
 
         Parameters
         ----------
-        files : Union[str, List[str]], optional
+        files : str | list[str] | None, optional
             File path(s) or URL(s).
-        dates : Union[pd.DatetimeIndex, List[datetime], datetime, str], optional
+        dates : pd.DatetimeIndex | list[datetime.datetime] | datetime.datetime | str | None, optional
             Dates to retrieve. If files is None, this is used to build URLs.
         **kwargs : dict
             Additional arguments passed to XarrayDriver.open.
@@ -39,6 +39,11 @@ class NESDISEPSVIIRSReader(GriddedReader):
         -------
         xr.Dataset
             The NESDIS EPS VIIRS dataset.
+
+        Examples
+        --------
+        >>> reader = NESDISEPSVIIRSReader()
+        >>> ds = reader.open_dataset(dates="2023-01-01")
         """
         if files is None:
             if dates is None:
@@ -66,13 +71,18 @@ class NESDISEPSVIIRSReader(GriddedReader):
 
         Parameters
         ----------
-        dates : Union[pd.DatetimeIndex, List[datetime], datetime, str]
+        dates : pd.DatetimeIndex | list[datetime.datetime] | datetime.datetime | str
             Dates to retrieve.
 
         Returns
         -------
-        List[str]
+        list[str]
             List of FTP URLs.
+
+        Examples
+        --------
+        >>> reader = NESDISEPSVIIRSReader()
+        >>> urls = reader.build_urls("2023-01-01")
         """
         if isinstance(dates, str | datetime.datetime | pd.Timestamp):
             dates = pd.DatetimeIndex([pd.to_datetime(dates)])
@@ -105,6 +115,10 @@ def nesdis_eps_viirs_preprocess(ds: xr.Dataset) -> xr.Dataset:
     -------
     xr.Dataset
         Processed dataset.
+
+    Examples
+    --------
+    >>> ds = nesdis_eps_viirs_preprocess(ds)
     """
     # 1. Standardize dimensions and coordinates
     ds = standardize_satellite_coords(ds)
@@ -119,13 +133,19 @@ def nesdis_eps_viirs_preprocess(ds: xr.Dataset) -> xr.Dataset:
         lon_max = -1.0 * lon_min
         lat_min = -89.875
         lat_max = -1.0 * lat_min
-        lons = np.linspace(lon_min, lon_max, nlon)
+        lons = np.linspace(lon_min, lon_max, nlon).astype(np.float32)
         # EPS uses descending latitudes (lat_max to lat_min)
-        lats = np.linspace(lat_max, lat_min, nlat)
+        lats = np.linspace(lat_max, lat_min, nlat).astype(np.float32)
 
         # Lazy coordinate generation using xr.broadcast
         lon1d = xr.DataArray(lons, dims=("x",), name="longitude")
         lat1d = xr.DataArray(lats, dims=("y",), name="latitude")
+
+        # Handle Dask if the dataset is chunked
+        if hasattr(ds, "chunks") and ds.chunks:
+            lon1d = lon1d.chunk({"x": ds.chunks.get("x", "auto")})
+            lat1d = lat1d.chunk({"y": ds.chunks.get("y", "auto")})
+
         lat2d, lon2d = xr.broadcast(lat1d, lon1d)
 
         ds = ds.assign_coords(
@@ -151,5 +171,11 @@ def nesdis_eps_viirs_preprocess(ds: xr.Dataset) -> xr.Dataset:
                 "standard_name": "atmosphere_optical_thickness_due_to_ambient_aerosol",
             }
         )
+
+    # 5. Scientific Hygiene
+    ds = _scientific_hygiene(ds)
+
+    # 6. Update history
+    ds = update_history(ds, "Preprocessed NESDIS EPS VIIRS data.")
 
     return ds

--- a/tests/test_aero_nesdis_eps_viirs.py
+++ b/tests/test_aero_nesdis_eps_viirs.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+from monetio.readers.nesdis_eps_viirs import nesdis_eps_viirs_preprocess
+
+def make_mock_ds(seed=42):
+    """Create a mock NESDIS EPS VIIRS dataset."""
+    nlat = 10
+    nlon = 20
+
+    rng = np.random.default_rng(seed)
+    # Mock data variable with a dummy time dimension to match expand_dims in preprocess
+    # Actually, preprocess adds time dimension if not present.
+    # The original data in the file is (y, x)
+    data = rng.standard_normal((nlat, nlon)).astype(np.float32)
+    data[0, 0] = -1.0  # Should be masked
+
+    ds = xr.Dataset(
+        data_vars={
+            "aot_ip_out": (("y", "x"), data),
+        },
+        attrs={
+            "time_coverage_start": "2023-01-01T00:00:00Z",
+        }
+    )
+    return ds
+
+def test_nesdis_eps_viirs_eager_lazy_consistency():
+    """Verify Eager (NumPy) and Lazy (Dask) consistency for NESDIS EPS VIIRS reader."""
+    ds_eager = make_mock_ds()
+
+    # 1. Process Eager
+    ds_eager_proc = nesdis_eps_viirs_preprocess(ds_eager)
+
+    # 2. Process Lazy
+    ds_lazy = make_mock_ds().chunk({"y": 5, "x": 5})
+    ds_lazy_proc = nesdis_eps_viirs_preprocess(ds_lazy)
+
+    # Verify laziness
+    assert hasattr(ds_lazy_proc.aod_550.data, "dask")
+    assert hasattr(ds_lazy_proc.latitude.data, "dask")
+    assert hasattr(ds_lazy_proc.longitude.data, "dask")
+
+    # 3. Compare Results
+    # Compute lazy result
+    ds_lazy_computed = ds_lazy_proc.compute()
+
+    # Assert coordinates are identical
+    xr.testing.assert_allclose(ds_eager_proc.latitude, ds_lazy_computed.latitude)
+    xr.testing.assert_allclose(ds_eager_proc.longitude, ds_lazy_computed.longitude)
+
+    # Assert data is identical (including masking)
+    xr.testing.assert_allclose(ds_eager_proc.aod_550, ds_lazy_computed.aod_550)
+
+    # Assert masking worked (-1.0 -> NaN)
+    # Note: aod_550 becomes (time, y, x) after preprocess
+    val = ds_eager_proc.aod_550.values[0, 0, 0]
+    assert np.isnan(val)
+
+    # Assert Time
+    assert ds_eager_proc.time.values == ds_lazy_computed.time.values
+
+    # Assert History
+    assert "history" in ds_eager_proc.attrs
+    assert "Preprocessed NESDIS EPS VIIRS data" in ds_eager_proc.attrs["history"]
+    assert "history" in ds_lazy_proc.attrs
+    assert "Preprocessed NESDIS EPS VIIRS data" in ds_lazy_proc.attrs["history"]
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This PR modernizes the `NESDISEPSVIIRSReader` in `monetio/readers/nesdis_eps_viirs.py` to align with the Aero Protocol.

Key changes:
1.  **Lazy Coordinate Generation**: Refactored `nesdis_eps_viirs_preprocess` to generate latitude and longitude lazily. It now checks for Dask chunks and applies them to the 1D arrays before broadcasting, ensuring that the resulting coordinates remain Dask-backed if the input dataset is.
2.  **Scientific Hygiene**: Integrated the centralized `_scientific_hygiene` utility to ensure that standard coordinates (`latitude`, `longitude`, `time`) are correctly set and that string attributes are stripped of whitespace.
3.  **Provenance Tracking**: Added `update_history` calls to track the preprocessing steps.
4.  **Documentation & Typing**: Updated all functions to use NumPy-style docstrings, including mandatory `Examples` sections, and modernized type hints to use PEP 585 syntax.
5.  **Validation**: Added `tests/test_aero_nesdis_eps_viirs.py` which verifies that the reader produces identical results (data, coordinates, masking, and metadata) across both Eager (NumPy) and Lazy (Dask) backends.

Verified with:
- `ruff check monetio/readers/nesdis_eps_viirs.py`
- `pytest tests/test_aero_nesdis_eps_viirs.py`
- `pytest tests/test_aero_hygiene.py tests/test_aero_viirs_jrr.py tests/test_aero_nesdis_edr_viirs.py tests/test_aero_nesdis_frp.py` (to ensure no regressions in related satellite/hygiene logic).

---
*PR created automatically by Jules for task [3046943683207830881](https://jules.google.com/task/3046943683207830881) started by @bbakernoaa*