### PR TITLE
Modernize OMPS Reader to Aero Protocol

### DIFF
--- a/monetio/readers/omps.py
+++ b/monetio/readers/omps.py
@@ -3,8 +3,13 @@
 import pandas as pd
 import xarray as xr
 
-from .base import GriddedReader, register_reader
-from .sat_utils import standardize_satellite_coords, tai93_to_datetime, update_history
+from .base import GriddedReader, _scientific_hygiene, register_reader
+from .sat_utils import (
+    add_time_coord,
+    standardize_satellite_coords,
+    tai93_to_datetime,
+    update_history,
+)
 
 
 @register_reader("omps")
@@ -18,6 +23,11 @@ class OMPSReader(GriddedReader):
         self,
         files: str | list[str],
         product: str = "nmto3_l2",
+        use_virtualizarr: bool = False,
+        virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
+        use_dask: bool = False,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -29,6 +39,16 @@ class OMPSReader(GriddedReader):
             File path(s) or URL(s).
         product : str, optional
             OMPS product: 'nmto3_l2' (default) or 'nmto3_l3'.
+        use_virtualizarr : bool, optional
+            Whether to use VirtualiZarr, by default False.
+        virtualizarr_file : str or None, optional
+            Path to the VirtualiZarr file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
+        use_dask : bool, optional
+            Whether to use Dask for lazy loading, by default False.
         **kwargs : dict
             Additional arguments passed to XarrayDriver.open.
 
@@ -47,7 +67,15 @@ class OMPSReader(GriddedReader):
 
         # L2 data often has different cross-track dimensions if not carefully selected,
         # but standard products should be consistent.
-        ds = super().open_dataset(files, **kwargs)
+        ds = super().open_dataset(
+            files,
+            use_virtualizarr=use_virtualizarr,
+            virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
+            use_dask=use_dask,
+            **kwargs,
+        )
 
         # Update history
         ds = update_history(ds, f"Read OMPS {product} data.")
@@ -73,8 +101,10 @@ def omps_preprocess(ds: xr.Dataset, product: str = "nmto3_l2") -> xr.Dataset:
 
     Examples
     --------
-    >>> ds = reader.open_dataset(files, product='nmto3_l2')
-    >>> ds = omps_preprocess(ds, product='nmto3_l2')
+    >>> import xarray as xr
+    >>> from monetio.readers.omps import omps_preprocess
+    >>> ds = xr.Dataset({"ColumnAmountO3": (("scanline", "ground_pixel"), [[250, 260]])})
+    >>> ds = omps_preprocess(ds, product="nmto3_l2")
     """
     if product == "nmto3_l2":
         ds = _preprocess_nmto3_l2(ds)
@@ -83,6 +113,9 @@ def omps_preprocess(ds: xr.Dataset, product: str = "nmto3_l2") -> xr.Dataset:
 
     # Standardize coordinates
     ds = standardize_satellite_coords(ds)
+
+    # Scientific Hygiene
+    ds = _scientific_hygiene(ds)
 
     return ds
 
@@ -100,20 +133,11 @@ def _preprocess_nmto3_l2(ds: xr.Dataset) -> xr.Dataset:
     -------
     xr.Dataset
         Processed dataset with standard names and lazily converted time.
+
+    Examples
+    --------
+    >>> ds = _preprocess_nmto3_l2(ds)
     """
-    # Group names might be present if opened with xarray directly without group specification,
-    # but typically we expect them to be at root or in specific groups.
-    # If using h5netcdf, we might need to handle groups.
-
-    # Check if we have GeolocationData group
-    if (
-        "GeolocationData" in ds.data_vars or "GeolocationData" in ds.groups
-        if hasattr(ds, "groups")
-        else False
-    ):
-        # This means it might have been opened without group selection
-        pass
-
     # Basic mapping of variables if they are in groups
     mapping = {
         "GeolocationData/Latitude": "latitude",
@@ -192,6 +216,10 @@ def _preprocess_nmto3_l3(ds: xr.Dataset) -> xr.Dataset:
     -------
     xr.Dataset
         Processed dataset with standard names and 2D coordinates.
+
+    Examples
+    --------
+    >>> ds = _preprocess_nmto3_l3(ds)
     """
     root_mapping = {
         "Latitude": "lat",
@@ -210,22 +238,13 @@ def _preprocess_nmto3_l3(ds: xr.Dataset) -> xr.Dataset:
         # Generate 2D meshgrid lazily
         lon2d, lat2d = xr.broadcast(ds.lon, ds.lat)
         ds = ds.assign_coords(
-            latitude=(("lat", "lon"), lat2d, {"units": "degrees_north"}),
-            longitude=(("lat", "lon"), lon2d, {"units": "degrees_east"}),
+            latitude=lat2d.assign_attrs({"units": "degrees_north"}),
+            longitude=lon2d.assign_attrs({"units": "degrees_east"}),
         )
 
     # Handle Time from attributes if available
     if "time" not in ds.coords:
-        # L3 attribute 'Date'
-        date_attr = ds.attrs.get("Date")
-        if date_attr:
-            if isinstance(date_attr, bytes):
-                date_attr = date_attr.decode("UTF-8")
-            try:
-                ds["time"] = [pd.to_datetime(date_attr)]
-                ds = ds.expand_dims("time")
-            except Exception:
-                pass
+        ds = add_time_coord(ds, time_attr="Date")
 
     # Masking
     if "ozone_column" in ds.data_vars:

--- a/monetio/readers/omps.py
+++ b/monetio/readers/omps.py
@@ -1,6 +1,5 @@
 """OMPS Reader"""
 
-import pandas as pd
 import xarray as xr
 
 from .base import GriddedReader, _scientific_hygiene, register_reader

--- a/tests/test_aero_omps.py
+++ b/tests/test_aero_omps.py
@@ -1,0 +1,129 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from monetio.readers.omps import omps_preprocess
+
+
+@pytest.mark.parametrize("lazy", [True, False])
+def test_omps_l2_consistency(lazy):
+    """Verify Eager and Lazy consistency for OMPS L2 preprocessing."""
+    # Create dummy L2 data
+    # Dimensions: scanline, ground_pixel
+    n_scan = 3
+    n_pixel = 4
+
+    # TAI93: seconds since 1993-01-01
+    tai93_start = (pd.Timestamp("2024-01-01") - pd.Timestamp("1993-01-01")).total_seconds()
+    time_raw = np.full(n_scan, tai93_start) + np.arange(n_scan) * 100.0
+
+    ds = xr.Dataset(
+        {
+            "ColumnAmountO3": (
+                ("scanline", "ground_pixel"),
+                np.array([[300.0, 400.0, 50.0, 750.0], [300.0, 300.0, 300.0, 300.0], [0.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+                {"units": " DU ", "long_name": " Total Ozone "},
+            ),
+            "Time": (("scanline",), time_raw),
+            "Latitude": (("scanline", "ground_pixel"), np.zeros((n_scan, n_pixel))),
+            "Longitude": (("scanline", "ground_pixel"), np.zeros((n_scan, n_pixel))),
+            "RadiativeCloudFraction": (("scanline", "ground_pixel"), np.zeros((n_scan, n_pixel))),
+            "QualityFlags": (("scanline", "ground_pixel"), np.zeros((n_scan, n_pixel), dtype=np.int32)),
+        }
+    )
+
+    if lazy:
+        ds = ds.chunk({"scanline": 1})
+
+    ds_out = omps_preprocess(ds, product="nmto3_l2")
+
+    # Verify coordinates
+    assert "latitude" in ds_out.coords
+    assert "longitude" in ds_out.coords
+    assert "time" in ds_out.coords
+    assert ds_out.y.size == n_scan
+    assert ds_out.x.size == n_pixel
+
+    # Verify time conversion
+    expected_time = pd.Timestamp("2024-01-01")
+    assert ds_out.time.values[0] == np.datetime64(expected_time)
+
+    # Verify masking (L2: 50 <= ozone <= 700)
+    ozone = ds_out.ozone_column.values
+    assert ozone[0, 0] == 300.0
+    assert ozone[0, 1] == 400.0
+    assert ozone[0, 2] == 50.0
+    assert np.isnan(ozone[0, 3])  # 750 > 700
+
+    # Verify Scientific Hygiene (whitespace stripping)
+    assert ds_out.ozone_column.attrs["units"] == "DU"
+    assert ds_out.ozone_column.attrs["long_name"] == "Total Ozone"
+
+    if lazy:
+        assert ds_out.ozone_column.chunks is not None
+
+
+@pytest.mark.parametrize("lazy", [True, False])
+def test_omps_l3_consistency(lazy):
+    """Verify Eager and Lazy consistency for OMPS L3 preprocessing."""
+    # Create dummy L3 data
+    # Dimensions: lat, lon
+    n_lat = 180
+    n_lon = 360
+
+    ds = xr.Dataset(
+        {
+            "ColumnAmountO3": (
+                ("lat", "lon"),
+                np.ones((n_lat, n_lon), dtype=np.float32) * 300.0,
+                {"units": "DU"},
+            ),
+            "Latitude": (("lat",), np.linspace(-90, 90, n_lat)),
+            "Longitude": (("lon",), np.linspace(-180, 180, n_lon)),
+        },
+        attrs={"Date": "2024-01-01"},
+    )
+
+    if lazy:
+        ds = ds.chunk({"lat": 90})
+
+    ds_out = omps_preprocess(ds, product="nmto3_l3")
+
+    # Verify coordinates (L3 should have 2D lat/lon assigned)
+    assert "latitude" in ds_out.coords
+    assert "longitude" in ds_out.coords
+    assert ds_out.latitude.ndim == 2
+    assert ds_out.longitude.ndim == 2
+
+    # Verify time assignment from Date attribute
+    assert "time" in ds_out.coords
+    assert ds_out.time.values[0] == np.datetime64("2024-01-01")
+
+    # Verify masking (L3: ozone >= 0)
+    assert not np.isnan(ds_out.ozone_column.values).any()
+
+    if lazy:
+        assert ds_out.ozone_column.chunks is not None
+
+
+def test_omps_l2_quality_masking():
+    """Verify L2 quality flag masking."""
+    ds = xr.Dataset(
+        {
+            "ColumnAmountO3": (("scanline", "ground_pixel"), [[300.0, 300.0], [300.0, 300.0]]),
+            "Time": (("scanline",), [0.0, 100.0]),
+            "Latitude": (("scanline", "ground_pixel"), np.zeros((2, 2))),
+            "Longitude": (("scanline", "ground_pixel"), np.zeros((2, 2))),
+            "RadiativeCloudFraction": (("scanline", "ground_pixel"), [[0.0, 0.4], [0.0, 0.0]]),
+            "QualityFlags": (("scanline", "ground_pixel"), [[0, 0], [137, 138]]),
+        }
+    )
+
+    ds_out = omps_preprocess(ds, product="nmto3_l2")
+    ozone = ds_out.ozone_column.values
+
+    assert ozone[0, 0] == 300.0
+    assert np.isnan(ozone[0, 1])  # Cloud fraction 0.4 > 0.3
+    assert ozone[1, 0] == 300.0  # Flag 137 < 138
+    assert np.isnan(ozone[1, 1])  # Flag 138 is bad

--- a/tests/test_aero_omps.py
+++ b/tests/test_aero_omps.py
@@ -22,14 +22,24 @@ def test_omps_l2_consistency(lazy):
         {
             "ColumnAmountO3": (
                 ("scanline", "ground_pixel"),
-                np.array([[300.0, 400.0, 50.0, 750.0], [300.0, 300.0, 300.0, 300.0], [0.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+                np.array(
+                    [
+                        [300.0, 400.0, 50.0, 750.0],
+                        [300.0, 300.0, 300.0, 300.0],
+                        [0.0, 0.0, 0.0, 0.0],
+                    ],
+                    dtype=np.float32,
+                ),
                 {"units": " DU ", "long_name": " Total Ozone "},
             ),
             "Time": (("scanline",), time_raw),
             "Latitude": (("scanline", "ground_pixel"), np.zeros((n_scan, n_pixel))),
             "Longitude": (("scanline", "ground_pixel"), np.zeros((n_scan, n_pixel))),
             "RadiativeCloudFraction": (("scanline", "ground_pixel"), np.zeros((n_scan, n_pixel))),
-            "QualityFlags": (("scanline", "ground_pixel"), np.zeros((n_scan, n_pixel), dtype=np.int32)),
+            "QualityFlags": (
+                ("scanline", "ground_pixel"),
+                np.zeros((n_scan, n_pixel), dtype=np.int32),
+            ),
         }
     )
 


### PR DESCRIPTION
Modernized the OMPS (Ozone Mapping and Profiler Suite) reader to align with the Aero Protocol. This includes explicitly supporting virtualization parameters in the entry point, upgrading preprocessing logic to be strictly lazy and backend-agnostic, and improving code maintainability through strict typing and standardized documentation. Verified the refactor with a new dual-backend test suite.

---
*PR created automatically by Jules for task [12907883211966884134](https://jules.google.com/task/12907883211966884134) started by @bbakernoaa*