### PR TITLE
Refactor IOAPI Readers for Standardized Dimension and Variable Naming

### DIFF
--- a/monetio/readers/base.py
+++ b/monetio/readers/base.py
@@ -763,6 +763,72 @@ def _get_ioapi_times(ds: xr.Dataset) -> xr.Dataset:
     return ds
 
 
+def _harmonize_ioapi_dims(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Standardize IOAPI dimension names (COL, ROW, LAY) to (x, y, z) lazily.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Input dataset.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset with standardized dimensions.
+    """
+    rename_dict = {}
+    if "COL" in ds.dims:
+        rename_dict["COL"] = "x"
+    if "ROW" in ds.dims:
+        rename_dict["ROW"] = "y"
+    if "LAY" in ds.dims:
+        rename_dict["LAY"] = "z"
+
+    if rename_dict:
+        ds = ds.rename(rename_dict)
+        ds = update_history(ds, f"Renamed dimensions: {rename_dict}")
+
+    return ds
+
+
+def _harmonize_ioapi_vars(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Standardize IOAPI variable names and remove redundant data variables.
+
+    Parameters
+    ----------
+    ds : xarray.Dataset
+        Input dataset.
+
+    Returns
+    -------
+    xarray.Dataset
+        Dataset with standardized variables.
+    """
+    # 1. Standardize variable names to lowercase
+    mapping = {v: v.lower() for v in ds.data_vars}
+    # Avoid collisions with existing coordinates
+    mapping = {k: v for k, v in mapping.items() if v not in ds.coords}
+    ds = ds.rename(mapping)
+
+    # 2. Drop redundant variables that are now coordinates
+    # This prevents cluttering the data_vars when they have been promoted
+    to_drop = [v for v in ds.data_vars if v in ds.coords]
+
+    # Specific common ones in IOAPI that might be present but promoted/renamed
+    # e.g. 'lat', 'lon', 'tflag'
+    for redundant in ["lat", "lon", "tflag"]:
+        if redundant in ds.data_vars:
+            to_drop.append(redundant)
+
+    if to_drop:
+        ds = ds.drop_vars(list(set(to_drop)))
+        ds = update_history(ds, f"Dropped redundant data variables: {list(set(to_drop))}")
+
+    return ds
+
+
 def _scientific_hygiene(ds: xr.Dataset) -> xr.Dataset:
     """
     Apply standard scientific hygiene to the dataset.

--- a/monetio/readers/camx.py
+++ b/monetio/readers/camx.py
@@ -12,6 +12,8 @@ from .base import (
     _add_ioapi_latlon,
     _convert_to_ppb,
     _format_units,
+    _harmonize_ioapi_dims,
+    _harmonize_ioapi_vars,
     _scientific_hygiene,
     add_lazy_diagnostic,
     register_reader,
@@ -89,6 +91,31 @@ class CAMxReader(GriddedReader):
 
         return ds
 
+    def harmonize(self, ds: xr.Dataset) -> xr.Dataset:
+        """
+        Standardize variable names and metadata.
+
+        Parameters
+        ----------
+        ds : xr.Dataset
+            CAMx dataset.
+
+        Returns
+        -------
+        xr.Dataset
+            Harmonized dataset.
+        """
+        # 1. Standardize variable names and drop redundant ones
+        ds = _harmonize_ioapi_vars(ds)
+
+        # 2. Clean up attributes
+        ds = _scientific_hygiene(ds)
+
+        # Update history
+        ds = update_history(ds, "Harmonized CAMx dataset.")
+
+        return ds
+
 
 def camx_preprocess(
     ds: xr.Dataset,
@@ -143,20 +170,15 @@ def camx_preprocess(
     ds = _format_units(ds)
 
     # 5. Rename dimensions
-    rename_dict = {}
-    if "COL" in ds.dims:
-        rename_dict["COL"] = "x"
-    if "ROW" in ds.dims:
-        rename_dict["ROW"] = "y"
-    if "LAY" in ds.dims:
-        rename_dict["LAY"] = "z"
-    if rename_dict:
-        ds = ds.rename(rename_dict)
+    ds = _harmonize_ioapi_dims(ds)
 
     # 6. Predefined mapping tables (backward compatibility)
     ds = _predefined_mapping_tables(ds)
 
-    # 7. Scientific Hygiene
+    # 7. Harmonize variables (lowercase and drop redundant)
+    ds = _harmonize_ioapi_vars(ds)
+
+    # 8. Scientific Hygiene
     ds = _scientific_hygiene(ds)
 
     # Update history

--- a/monetio/readers/cmaq.py
+++ b/monetio/readers/cmaq.py
@@ -12,6 +12,8 @@ from .base import (
     _add_ioapi_latlon,
     _convert_to_ppb,
     _format_units,
+    _harmonize_ioapi_dims,
+    _harmonize_ioapi_vars,
     _scientific_hygiene,
     add_lazy_diagnostic,
     register_reader,
@@ -101,21 +103,14 @@ class CMAQReader(GriddedReader):
         xr.Dataset
             Harmonized dataset.
         """
-        # 1. Standardize variable names to lowercase
-        mapping = {v: v.lower() for v in ds.data_vars}
-        # Avoid collisions with existing coordinates
-        mapping = {k: v for k, v in mapping.items() if v not in ds.coords}
-        ds = ds.rename(mapping)
+        # 1. Standardize variable names and drop redundant ones
+        ds = _harmonize_ioapi_vars(ds)
 
-        # 2. Specific mappings for common species if they exist
-        # Rename back to standard if they were changed to something else or keep as is
-        # Actually, many users expect lowercase.
-
-        # 3. Clean up attributes
+        # 2. Clean up attributes
         ds = _scientific_hygiene(ds)
 
         # Update history
-        ds = update_history(ds, "Harmonized CMAQ dataset (lowercased variables).")
+        ds = update_history(ds, "Harmonized CMAQ dataset.")
 
         return ds
 
@@ -173,17 +168,12 @@ def cmaq_preprocess(
     ds = _format_units(ds)
 
     # 5. Rename dimensions
-    rename_dict = {}
-    if "COL" in ds.dims:
-        rename_dict["COL"] = "x"
-    if "ROW" in ds.dims:
-        rename_dict["ROW"] = "y"
-    if "LAY" in ds.dims:
-        rename_dict["LAY"] = "z"
-    if rename_dict:
-        ds = ds.rename(rename_dict)
+    ds = _harmonize_ioapi_dims(ds)
 
-    # 6. Scientific Hygiene
+    # 6. Harmonize variables (lowercase and drop redundant)
+    ds = _harmonize_ioapi_vars(ds)
+
+    # 7. Scientific Hygiene
     ds = _scientific_hygiene(ds)
 
     # Update history

--- a/tests/test_aero_camx.py
+++ b/tests/test_aero_camx.py
@@ -82,14 +82,14 @@ def test_camx_eager_lazy(tmp_path):
     assert "time" in ds_eager.coords
     assert "latitude" in ds_eager.coords
     assert "longitude" in ds_eager.coords
-    assert "O3" in ds_eager.data_vars
-    assert ds_eager.O3.attrs["units"] == "ppbV"  # Converted from ppm
+    assert "o3" in ds_eager.data_vars
+    assert ds_eager.o3.attrs["units"] == "ppbV"  # Converted from ppm
 
     # Lazy Mode
     # Note: Using chunks={} in open_dataset kwargs triggers dask
     ds_lazy = reader.open_dataset(files=str(fname), chunks={"time": 1}, engine="h5netcdf")
     assert isinstance(ds_lazy, xr.Dataset)
-    assert hasattr(ds_lazy.O3.data, "dask")
+    assert hasattr(ds_lazy.o3.data, "dask")
 
     # Verify values and coordinates consistency
     # This ensures that both Eager (NumPy) and Lazy (Dask) paths produce identical results.
@@ -99,10 +99,10 @@ def test_camx_eager_lazy(tmp_path):
     )
 
     # Check diagnostics
-    assert "NOx" in ds_eager.data_vars
+    assert "nox" in ds_eager.data_vars
     # NOX = NO + NO2 (now that we added NO2 to the mock)
-    expected_nox = ds_eager.NO + ds_eager.NO2
-    xr.testing.assert_allclose(ds_eager.NOx, expected_nox)
+    expected_nox = ds_eager.no + ds_eager.no2
+    xr.testing.assert_allclose(ds_eager.nox, expected_nox)
 
     # Verify history tracking
     assert "Added lazy diagnostic: NOx" in ds_eager.attrs["history"]

--- a/tests/test_aero_cmaq.py
+++ b/tests/test_aero_cmaq.py
@@ -87,11 +87,11 @@ def test_cmaq_preprocess_consistency():
 
     # 4. Consistency check
     # Check units conversion (ppmV -> ppbV)
-    assert ds_eager_res.O3.attrs["units"] == "ppbV"
-    xr.testing.assert_allclose(ds_eager_res.O3, ds_lazy_res.O3.compute())
+    assert ds_eager_res.o3.attrs["units"] == "ppbV"
+    xr.testing.assert_allclose(ds_eager_res.o3, ds_lazy_res.o3.compute())
 
     # 5. Laziness check
-    assert hasattr(ds_lazy_res.O3.data, "dask")
+    assert hasattr(ds_lazy_res.o3.data, "dask")
     assert hasattr(ds_lazy_res.latitude.data, "dask")
 
 
@@ -128,9 +128,9 @@ def test_cmaq_diagnostics():
 
     ds_res = cmaq_preprocess(ds)
 
-    assert "NOx" in ds_res.data_vars
-    assert hasattr(ds_res.NOx.data, "dask")
-    assert ds_res.NOx.attrs["units"] == "ppbV"  # Should be synced to ppbV
+    assert "nox" in ds_res.data_vars
+    assert hasattr(ds_res.nox.data, "dask")
+    assert ds_res.nox.attrs["units"] == "ppbV"  # Should be synced to ppbV
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR refactors the CMAQ and CAMx readers to use unified IOAPI harmonization utilities in monetio/readers/base.py. It standardizes dimension names (COL/ROW/LAY to x/y/z) and variable names (lowercase), while ensuring redundant data variables like lat, lon, and tflag are dropped once promoted to coordinates. The changes adhere to the Aero Protocol, maintaining laziness (Dask support) and providing consistent provenance via history tracking. Tests for both readers have been updated to reflect the standardized naming conventions and verify eager/lazy consistency.

---
*PR created automatically by Jules for task [1501686844101392289](https://jules.google.com/task/1501686844101392289) started by @bbakernoaa*