### PR TITLE
Modernize Virtualization and Dask API for MONETIO Readers

### DIFF
--- a/monetio/__init__.py
+++ b/monetio/__init__.py
@@ -123,21 +123,25 @@ def virtualize(source: str, files=None, output: str = None, backend: str = "kerc
     files : str or list of str, optional
         File path(s) or glob pattern(s).
     output : str, optional
-        Path to save the output reference (required for 'kerchunk' backend).
+        Path to save the output reference. For 'kerchunk' backend, this is the JSON file path.
+        For 'icechunk' backend, this is the Icechunk repository URL/path.
     backend : str, optional
         The virtualization backend. Must be "kerchunk" (default) or "icechunk".
     **kwargs : dict
         Additional arguments passed to the reader and driver.
     """
-    if backend == "kerchunk" and output is None:
-        raise ValueError("The 'output' parameter is required for the 'kerchunk' backend.")
+    if output is None:
+        raise ValueError("The 'output' parameter is required for virtualization.")
+
+    use_icechunk = backend == "icechunk"
 
     return load(
         source,
         files=files,
         use_virtualizarr=True,
-        virtualizarr_file=output,
-        virtualizarr_backend=backend,
+        virtualizarr_file=None if use_icechunk else output,
+        use_icechunk=use_icechunk,
+        icechunk_url=output if use_icechunk else None,
         **kwargs,
     )
 

--- a/monetio/cli.py
+++ b/monetio/cli.py
@@ -226,14 +226,24 @@ def openaq(dates, output, n_procs, lazy, as_pandas, wide_fmt):
 @cli.command(name="virtualizarr")
 @click.argument("files", nargs=-1)
 @click.option(
-    "--output", "-o", required=True, help="Output JSON file path for the VirtualiZarr reference."
+    "--output",
+    "-o",
+    required=True,
+    help="Output reference path. For 'kerchunk', this is a JSON file; for 'icechunk', a repository URL.",
+)
+@click.option(
+    "--backend",
+    "-b",
+    type=click.Choice(["kerchunk", "icechunk"]),
+    default="kerchunk",
+    help="Virtualization backend (default 'kerchunk').",
 )
 @click.option(
     "--concat-dim", default="time", help="Dimension to concatenate along (default 'time')."
 )
-def virtualizarr(files, output, concat_dim):
+def virtualizarr(files, output, backend, concat_dim):
     """
-    Pre-process files into a single VirtualiZarr reference JSON map.
+    Pre-process files into a single VirtualiZarr reference (Kerchunk or Icechunk).
     Especially useful for large geospatial datasets (MERRA2, GFS, etc.).
     """
     if not files:
@@ -260,11 +270,19 @@ def virtualizarr(files, output, concat_dim):
     from monetio.readers.drivers import XarrayDriver
 
     # We use XarrayDriver.open to handle the parsing natively and drop the dataset payload.
-    # It automatically saves the references to `virtualizarr_file`.
+    # It automatically saves the references to the specified output.
     xd = XarrayDriver()
+    use_icechunk = backend == "icechunk"
     try:
-        xd.open(list(files), use_virtualizarr=True, virtualizarr_file=output, concat_dim=concat_dim)
-        click.echo(f"Successfully generated {output}")
+        xd.open(
+            list(files),
+            use_virtualizarr=True,
+            virtualizarr_file=None if use_icechunk else output,
+            use_icechunk=use_icechunk,
+            icechunk_url=output if use_icechunk else None,
+            concat_dim=concat_dim,
+        )
+        click.echo(f"Successfully generated reference at {output} (backend: {backend})")
     except Exception as e:
         click.echo(f"Error generating VirtualiZarr reference: {e}")
 

--- a/monetio/readers/base.py
+++ b/monetio/readers/base.py
@@ -80,6 +80,8 @@ class GriddedReader(BaseReader):
         files: str | list[str],
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -96,6 +98,10 @@ class GriddedReader(BaseReader):
             Whether to use VirtualiZarr to create a virtual Zarr dataset, by default False.
         virtualizarr_file : str or None, optional
             Path to save/load the VirtualiZarr reference JSON file, by default None.
+        virtualizarr_backend : str, optional
+            Backend for VirtualiZarr references ("kerchunk" or "icechunk"), by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk for VirtualiZarr references, by default False.
         icechunk_url : str or None, optional
@@ -114,6 +120,8 @@ class GriddedReader(BaseReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,
@@ -138,6 +146,8 @@ class PointReader(BaseReader):
         # VirtualiZarr kwargs accepted but silently ignored for PointReaders
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         # Standard PointReader kwargs
@@ -158,6 +168,10 @@ class PointReader(BaseReader):
         use_virtualizarr : bool, optional
             Accepted but ignored for PointReaders (VirtualiZarr only applies to gridded data).
         virtualizarr_file : str or None, optional
+            Accepted but ignored for PointReaders.
+        virtualizarr_backend : str, optional
+            Accepted but ignored for PointReaders.
+        icechunk_repo : str or None, optional
             Accepted but ignored for PointReaders.
         use_icechunk : bool, optional
             Accepted but ignored for PointReaders.
@@ -186,8 +200,8 @@ class PointReader(BaseReader):
             lazy = True
 
         # VirtualiZarr kwargs (use_virtualizarr, virtualizarr_file,
-        # use_icechunk, icechunk_url) are silently discarded here
-        # and NOT forwarded to PandasDriver.
+        # virtualizarr_backend, icechunk_repo, use_icechunk, icechunk_url)
+        # are silently discarded here and NOT forwarded to PandasDriver.
         df = self.driver.open(files, read_method=read_method, lazy=lazy, meta=meta, **kwargs)
 
         df = self.harmonize(df)

--- a/monetio/readers/base.py
+++ b/monetio/readers/base.py
@@ -80,8 +80,8 @@ class GriddedReader(BaseReader):
         files: str | list[str],
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
-        virtualizarr_backend: str = "kerchunk",
-        icechunk_repo: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
         use_dask: bool = False,
         **kwargs,
     ) -> xr.Dataset:
@@ -96,9 +96,9 @@ class GriddedReader(BaseReader):
             Whether to use VirtualiZarr to create a virtual Zarr dataset, by default False.
         virtualizarr_file : str or None, optional
             Path to save/load the VirtualiZarr reference JSON file, by default None.
-        virtualizarr_backend : str, optional
-            Backend for VirtualiZarr references ("kerchunk" or "icechunk"), by default "kerchunk".
-        icechunk_repo : str or None, optional
+        use_icechunk : bool, optional
+            Whether to use Icechunk for VirtualiZarr references, by default False.
+        icechunk_url : str or None, optional
             Path to the Icechunk repository, by default None.
         use_dask : bool, optional
             Whether to use Dask for lazy loading, by default False.
@@ -114,8 +114,8 @@ class GriddedReader(BaseReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_backend=virtualizarr_backend,
-            icechunk_repo=icechunk_repo,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
             use_dask=use_dask,
             **kwargs,
         )
@@ -138,12 +138,13 @@ class PointReader(BaseReader):
         # VirtualiZarr kwargs accepted but silently ignored for PointReaders
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
-        virtualizarr_backend: str = "kerchunk",
-        icechunk_repo: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
         # Standard PointReader kwargs
         read_method: str = "read_csv",
         as_xarray: bool = True,
         lazy: bool = False,
+        use_dask: bool = False,
         meta: pd.DataFrame | pd.Series | dict | tuple | None = None,
         **kwargs,
     ) -> Union[pd.DataFrame, xr.Dataset, "dd.DataFrame"]:
@@ -158,9 +159,9 @@ class PointReader(BaseReader):
             Accepted but ignored for PointReaders (VirtualiZarr only applies to gridded data).
         virtualizarr_file : str or None, optional
             Accepted but ignored for PointReaders.
-        virtualizarr_backend : str, optional
+        use_icechunk : bool, optional
             Accepted but ignored for PointReaders.
-        icechunk_repo : str or None, optional
+        icechunk_url : str or None, optional
             Accepted but ignored for PointReaders.
         read_method : str, optional
             The pandas/dask reading method to use, by default "read_csv".
@@ -168,6 +169,8 @@ class PointReader(BaseReader):
             If True, return an xarray.Dataset, by default True.
         lazy : bool, optional
             If True, return a dask-backed object, by default False.
+        use_dask : bool, optional
+            Alias for `lazy`, by default False.
         meta : pd.DataFrame, pd.Series, dict, or tuple, optional
             Dask metadata to use for lazy loading, by default None.
         **kwargs : dict
@@ -178,8 +181,12 @@ class PointReader(BaseReader):
         Union[pd.DataFrame, xr.Dataset, dd.DataFrame]
             The loaded dataset.
         """
+        # Handle 'use_dask' as an alias for 'lazy'
+        if use_dask:
+            lazy = True
+
         # VirtualiZarr kwargs (use_virtualizarr, virtualizarr_file,
-        # virtualizarr_backend, icechunk_repo) are silently discarded here
+        # use_icechunk, icechunk_url) are silently discarded here
         # and NOT forwarded to PandasDriver.
         df = self.driver.open(files, read_method=read_method, lazy=lazy, meta=meta, **kwargs)
 

--- a/monetio/readers/camx.py
+++ b/monetio/readers/camx.py
@@ -34,6 +34,11 @@ class CAMxReader(GriddedReader):
         earth_radius: float = 6370000,
         convert_to_ppb: bool = True,
         drop_duplicates: bool = False,
+        use_virtualizarr: bool = False,
+        virtualizarr_file: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
+        use_dask: bool = False,
         **kwargs: Any,
     ) -> xr.Dataset:
         """
@@ -49,6 +54,16 @@ class CAMxReader(GriddedReader):
             Convert gas species from ppmV to ppbV, by default True.
         drop_duplicates : bool, optional
             Drop duplicate time steps within each file, by default False.
+        use_virtualizarr : bool, optional
+            Whether to use VirtualiZarr, by default False.
+        virtualizarr_file : str or None, optional
+            Path to the VirtualiZarr file, by default None.
+        use_icechunk : bool, optional
+            Whether to use Icechunk, by default False.
+        icechunk_url : str or None, optional
+            Path to the Icechunk repository, by default None.
+        use_dask : bool, optional
+            Whether to use Dask for lazy loading, by default False.
         **kwargs : Any
             Additional arguments passed to the driver.
 
@@ -77,7 +92,15 @@ class CAMxReader(GriddedReader):
         if "concat_dim" not in kwargs:
             kwargs["concat_dim"] = "time"
 
-        ds = self.driver.open(files, **kwargs)
+        ds = super().open_dataset(
+            files,
+            use_virtualizarr=use_virtualizarr,
+            virtualizarr_file=virtualizarr_file,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
+            use_dask=use_dask,
+            **kwargs,
+        )
 
         # 3. Finalize
         if drop_duplicates:

--- a/monetio/readers/camx.py
+++ b/monetio/readers/camx.py
@@ -36,6 +36,8 @@ class CAMxReader(GriddedReader):
         drop_duplicates: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -58,6 +60,10 @@ class CAMxReader(GriddedReader):
             Whether to use VirtualiZarr, by default False.
         virtualizarr_file : str or None, optional
             Path to the VirtualiZarr file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
@@ -96,6 +102,8 @@ class CAMxReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,

--- a/monetio/readers/chimere.py
+++ b/monetio/readers/chimere.py
@@ -22,6 +22,8 @@ class ChimereReader(GriddedReader):
         surf_only: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -42,6 +44,10 @@ class ChimereReader(GriddedReader):
             Whether to use VirtualiZarr to create a virtual Zarr dataset, by default False.
         virtualizarr_file : str or None, optional
             Path to save/load the VirtualiZarr reference JSON file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
@@ -78,6 +84,8 @@ class ChimereReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,

--- a/monetio/readers/chimere.py
+++ b/monetio/readers/chimere.py
@@ -22,8 +22,8 @@ class ChimereReader(GriddedReader):
         surf_only: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
-        virtualizarr_backend: str = "kerchunk",
-        icechunk_repo: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
         use_dask: bool = False,
         **kwargs: Any,
     ) -> xr.Dataset:
@@ -42,9 +42,9 @@ class ChimereReader(GriddedReader):
             Whether to use VirtualiZarr to create a virtual Zarr dataset, by default False.
         virtualizarr_file : str or None, optional
             Path to save/load the VirtualiZarr reference JSON file, by default None.
-        virtualizarr_backend : str, optional
-            Backend for VirtualiZarr references ("kerchunk" or "icechunk"), by default "kerchunk".
-        icechunk_repo : str or None, optional
+        use_icechunk : bool, optional
+            Whether to use Icechunk, by default False.
+        icechunk_url : str or None, optional
             Path to the Icechunk repository, by default None.
         use_dask : bool, optional
             Whether to use Dask for lazy loading, by default False.
@@ -78,8 +78,8 @@ class ChimereReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_backend=virtualizarr_backend,
-            icechunk_repo=icechunk_repo,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
             use_dask=use_dask,
             **kwargs,
         )

--- a/monetio/readers/cmaq.py
+++ b/monetio/readers/cmaq.py
@@ -34,6 +34,11 @@ class CMAQReader(GriddedReader):
         earth_radius: float = 6370000,
         convert_to_ppb: bool = True,
         drop_duplicates: bool = False,
+        use_virtualizarr: bool = False,
+        virtualizarr_file: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
+        use_dask: bool = False,
         **kwargs: Any,
     ) -> xr.Dataset:
         """
@@ -49,6 +54,16 @@ class CMAQReader(GriddedReader):
             Convert gas species from ppmV to ppbV, by default True.
         drop_duplicates : bool, optional
             Drop duplicate time steps within each file, by default False.
+        use_virtualizarr : bool, optional
+            Whether to use VirtualiZarr, by default False.
+        virtualizarr_file : str or None, optional
+            Path to the VirtualiZarr file, by default None.
+        use_icechunk : bool, optional
+            Whether to use Icechunk, by default False.
+        icechunk_url : str or None, optional
+            Path to the Icechunk repository, by default None.
+        use_dask : bool, optional
+            Whether to use Dask for lazy loading, by default False.
         **kwargs : Any
             Additional arguments passed to xarray.open_mfdataset or the driver.
 
@@ -75,7 +90,15 @@ class CMAQReader(GriddedReader):
             # Actually, preprocess runs BEFORE concatenation.
             kwargs["concat_dim"] = "time"
 
-        ds = self.driver.open(files, **kwargs)
+        ds = super().open_dataset(
+            files,
+            use_virtualizarr=use_virtualizarr,
+            virtualizarr_file=virtualizarr_file,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
+            use_dask=use_dask,
+            **kwargs,
+        )
 
         # 3. Finalize
         if drop_duplicates:

--- a/monetio/readers/cmaq.py
+++ b/monetio/readers/cmaq.py
@@ -36,6 +36,8 @@ class CMAQReader(GriddedReader):
         drop_duplicates: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -58,6 +60,10 @@ class CMAQReader(GriddedReader):
             Whether to use VirtualiZarr, by default False.
         virtualizarr_file : str or None, optional
             Path to the VirtualiZarr file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
@@ -94,6 +100,8 @@ class CMAQReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -1,8 +1,4 @@
-import os
-import tempfile
-import hashlib
 import warnings
-
 from collections.abc import Callable
 from typing import Union
 
@@ -63,14 +59,14 @@ def _select_store(file_list: list[str], storage_options: dict) -> tuple:
     return registry, file_list
 
 
-def _open_via_icechunk(vds, icechunk_repo: str, virtualizarr_file: str | None) -> xr.Dataset:
+def _open_via_icechunk(vds, icechunk_url: str, virtualizarr_file: str | None) -> xr.Dataset:
     """Store virtual references in Icechunk and return the dataset.
 
     Parameters
     ----------
     vds : virtualizarr.VirtualDataset
         The virtual dataset to persist.
-    icechunk_repo : str
+    icechunk_url : str
         Path (local or remote) to the Icechunk repository.
     virtualizarr_file : str | None
         Unused for Icechunk but accepted for interface consistency.
@@ -87,7 +83,7 @@ def _open_via_icechunk(vds, icechunk_repo: str, virtualizarr_file: str | None) -
             "Icechunk backend requires 'icechunk'. Install with: pip install monetio[icechunk]"
         )
 
-    repo = icechunk.Repository.open_or_create(icechunk_repo)
+    repo = icechunk.Repository.open_or_create(icechunk_url)
     session = repo.writable_session("main")
     store = session.store
 
@@ -176,8 +172,8 @@ class XarrayDriver:
         use_cubed: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
-        virtualizarr_backend: str = "kerchunk",
-        icechunk_repo: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -198,13 +194,12 @@ class XarrayDriver:
             Path to save/load the VirtualiZarr reference JSON file. If provided and the file
             exists, the references will be loaded from it. If the file does not exist,
             the references will be computed and saved to this path.
-        virtualizarr_backend : str, optional
-            Backend for VirtualiZarr references. Must be ``"kerchunk"`` (default) or
-            ``"icechunk"``. When ``"icechunk"`` is selected, references are stored in
-            an Icechunk repository instead of a kerchunk JSON file.
-        icechunk_repo : str, optional
-            Path to the Icechunk repository. Required when
-            ``virtualizarr_backend="icechunk"``.
+        use_icechunk : bool, optional
+            Whether to use Icechunk as the storage backend for VirtualiZarr references,
+            by default False. If True, references are stored in an Icechunk repository.
+            If False, the default Kerchunk JSON format is used.
+        icechunk_url : str, optional
+            Path or URL to the Icechunk repository. Required when ``use_icechunk=True``.
         **kwargs : dict
             Additional arguments passed to xarray open functions.
 
@@ -213,12 +208,24 @@ class XarrayDriver:
         xr.Dataset
             The loaded dataset.
         """
-        # Validate virtualizarr_backend parameter
-        if virtualizarr_backend not in ("kerchunk", "icechunk"):
-            raise ValueError(
-                f"Invalid virtualizarr_backend '{virtualizarr_backend}'. "
-                "Must be 'kerchunk' or 'icechunk'."
+        # Deprecation fallbacks for renamed parameters
+        if "virtualizarr_backend" in kwargs:
+            warnings.warn(
+                "The 'virtualizarr_backend' parameter is deprecated. Use 'use_icechunk' instead.",
+                FutureWarning,
+                stacklevel=2,
             )
+            vb = kwargs.pop("virtualizarr_backend")
+            if vb == "icechunk":
+                use_icechunk = True
+        if "icechunk_repo" in kwargs:
+            warnings.warn(
+                "The 'icechunk_repo' parameter is deprecated. Use 'icechunk_url' instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            icechunk_url = kwargs.pop("icechunk_repo")
+
         # Prepare kwargs for xarray
         xr_kwargs = kwargs.copy()
 
@@ -265,7 +272,7 @@ class XarrayDriver:
             # --- Kerchunk cache: load existing refs if available ---
             refs = None
             if (
-                virtualizarr_backend == "kerchunk"
+                not use_icechunk
                 and virtualizarr_file is not None
                 and os.path.exists(virtualizarr_file)
             ):
@@ -273,8 +280,6 @@ class XarrayDriver:
                     with open(virtualizarr_file) as f_ref:
                         refs = ujson.load(f_ref)
                 except Exception as e:
-                    import warnings
-
                     warnings.warn(f"Failed to load virtualizarr_file {virtualizarr_file}: {e}")
                     refs = None
 
@@ -297,8 +302,8 @@ class XarrayDriver:
                     )
 
                 # --- Branch on backend ---
-                if virtualizarr_backend == "icechunk":
-                    ds = _open_via_icechunk(vds, icechunk_repo, virtualizarr_file)
+                if use_icechunk:
+                    ds = _open_via_icechunk(vds, icechunk_url, virtualizarr_file)
                     if preprocess:
                         ds = preprocess(ds)
                     return ds
@@ -311,8 +316,6 @@ class XarrayDriver:
                         with open(virtualizarr_file, "w") as f_ref:
                             ujson.dump(refs, f_ref)
                     except Exception as e:
-                        import warnings
-
                         warnings.warn(f"Failed to save virtualizarr_file {virtualizarr_file}: {e}")
 
             remote_protocol = "file"

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -172,6 +172,8 @@ class XarrayDriver:
         use_cubed: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         **kwargs,
@@ -194,6 +196,12 @@ class XarrayDriver:
             Path to save/load the VirtualiZarr reference JSON file. If provided and the file
             exists, the references will be loaded from it. If the file does not exist,
             the references will be computed and saved to this path.
+        virtualizarr_backend : str, optional
+            Backend for VirtualiZarr references ("kerchunk" or "icechunk"), by default "kerchunk".
+            Note: This parameter is deprecated in favor of `use_icechunk`.
+        icechunk_repo : str, optional
+            Path to the Icechunk repository. Required when ``virtualizarr_backend="icechunk"``.
+            Note: This parameter is deprecated in favor of `icechunk_url`.
         use_icechunk : bool, optional
             Whether to use Icechunk as the storage backend for VirtualiZarr references,
             by default False. If True, references are stored in an Icechunk repository.
@@ -208,23 +216,28 @@ class XarrayDriver:
         xr.Dataset
             The loaded dataset.
         """
-        # Deprecation fallbacks for renamed parameters
-        if "virtualizarr_backend" in kwargs:
+        # Handle deprecated parameters
+        if virtualizarr_backend == "icechunk":
             warnings.warn(
-                "The 'virtualizarr_backend' parameter is deprecated. Use 'use_icechunk' instead.",
+                "The 'virtualizarr_backend' parameter is deprecated. Use 'use_icechunk=True' instead.",
                 FutureWarning,
                 stacklevel=2,
             )
-            vb = kwargs.pop("virtualizarr_backend")
-            if vb == "icechunk":
-                use_icechunk = True
-        if "icechunk_repo" in kwargs:
+            use_icechunk = True
+        if icechunk_repo is not None:
             warnings.warn(
                 "The 'icechunk_repo' parameter is deprecated. Use 'icechunk_url' instead.",
                 FutureWarning,
                 stacklevel=2,
             )
-            icechunk_url = kwargs.pop("icechunk_repo")
+            icechunk_url = icechunk_repo
+
+        # Validate backend selection
+        if not use_icechunk and virtualizarr_backend not in ("kerchunk", "icechunk"):
+            raise ValueError(
+                f"Invalid virtualizarr_backend '{virtualizarr_backend}'. "
+                "Must be 'kerchunk' or 'icechunk'."
+            )
 
         # Prepare kwargs for xarray
         xr_kwargs = kwargs.copy()

--- a/monetio/readers/modis_l2.py
+++ b/monetio/readers/modis_l2.py
@@ -18,6 +18,8 @@ class MODISL2Reader(GriddedReader):
         variable_dict: dict = None,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -37,6 +39,10 @@ class MODISL2Reader(GriddedReader):
             Whether to use VirtualiZarr, by default False.
         virtualizarr_file : str or None, optional
             Path to the VirtualiZarr file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
@@ -74,6 +80,8 @@ class MODISL2Reader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,

--- a/monetio/readers/modis_l2.py
+++ b/monetio/readers/modis_l2.py
@@ -16,6 +16,11 @@ class MODISL2Reader(GriddedReader):
         self,
         files: str | list[str],
         variable_dict: dict = None,
+        use_virtualizarr: bool = False,
+        virtualizarr_file: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
+        use_dask: bool = False,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -28,6 +33,16 @@ class MODISL2Reader(GriddedReader):
         variable_dict : dict, optional
             Dictionary of variables to read with metadata (scale, minimum, maximum, quality_flag).
             Example: `{'AOD_550': {'scale': 0.001, 'quality_flag': 3}}`
+        use_virtualizarr : bool, optional
+            Whether to use VirtualiZarr, by default False.
+        virtualizarr_file : str or None, optional
+            Path to the VirtualiZarr file, by default None.
+        use_icechunk : bool, optional
+            Whether to use Icechunk, by default False.
+        icechunk_url : str or None, optional
+            Path to the Icechunk repository, by default None.
+        use_dask : bool, optional
+            Whether to use Dask for lazy loading, by default False.
         **kwargs : dict
             Additional arguments passed to the reader.
 
@@ -55,7 +70,15 @@ class MODISL2Reader(GriddedReader):
             # or the user can pass drop_variables.
             pass
 
-        ds = super().open_dataset(files, **kwargs)
+        ds = super().open_dataset(
+            files,
+            use_virtualizarr=use_virtualizarr,
+            virtualizarr_file=virtualizarr_file,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
+            use_dask=use_dask,
+            **kwargs,
+        )
 
         # Filter to requested variables if variable_dict is provided
         if variable_dict is not None:

--- a/monetio/readers/mopitt.py
+++ b/monetio/readers/mopitt.py
@@ -20,6 +20,8 @@ class MOPITTReader(GriddedReader):
         files: str | list[str],
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -36,6 +38,10 @@ class MOPITTReader(GriddedReader):
             Whether to use VirtualiZarr, by default False.
         virtualizarr_file : str or None, optional
             Path to the VirtualiZarr file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
@@ -60,6 +66,8 @@ class MOPITTReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,

--- a/monetio/readers/mopitt.py
+++ b/monetio/readers/mopitt.py
@@ -18,6 +18,11 @@ class MOPITTReader(GriddedReader):
     def open_dataset(
         self,
         files: str | list[str],
+        use_virtualizarr: bool = False,
+        virtualizarr_file: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
+        use_dask: bool = False,
         **kwargs,
     ) -> xr.Dataset:
         """
@@ -27,6 +32,16 @@ class MOPITTReader(GriddedReader):
         ----------
         files : Union[str, List[str]]
             File path(s) or URL(s).
+        use_virtualizarr : bool, optional
+            Whether to use VirtualiZarr, by default False.
+        virtualizarr_file : str or None, optional
+            Path to the VirtualiZarr file, by default None.
+        use_icechunk : bool, optional
+            Whether to use Icechunk, by default False.
+        icechunk_url : str or None, optional
+            Path to the Icechunk repository, by default None.
+        use_dask : bool, optional
+            Whether to use Dask for lazy loading, by default False.
         **kwargs : dict
             Additional arguments passed to XarrayDriver.open.
 
@@ -41,7 +56,15 @@ class MOPITTReader(GriddedReader):
         if "engine" not in kwargs:
             kwargs["engine"] = "h5netcdf"
 
-        ds = super().open_dataset(files, **kwargs)
+        ds = super().open_dataset(
+            files,
+            use_virtualizarr=use_virtualizarr,
+            virtualizarr_file=virtualizarr_file,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
+            use_dask=use_dask,
+            **kwargs,
+        )
 
         # Update history
         ds = update_history(ds, "Read MOPITT L3 data.")

--- a/monetio/readers/omps.py
+++ b/monetio/readers/omps.py
@@ -24,6 +24,8 @@ class OMPSReader(GriddedReader):
         product: str = "nmto3_l2",
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -42,6 +44,10 @@ class OMPSReader(GriddedReader):
             Whether to use VirtualiZarr, by default False.
         virtualizarr_file : str or None, optional
             Path to the VirtualiZarr file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
@@ -70,6 +76,8 @@ class OMPSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,

--- a/monetio/readers/omps.py
+++ b/monetio/readers/omps.py
@@ -24,8 +24,8 @@ class OMPSReader(GriddedReader):
         product: str = "nmto3_l2",
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
-        virtualizarr_backend: str = "kerchunk",
-        icechunk_repo: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
         use_dask: bool = False,
         **kwargs,
     ) -> xr.Dataset:
@@ -42,9 +42,9 @@ class OMPSReader(GriddedReader):
             Whether to use VirtualiZarr, by default False.
         virtualizarr_file : str or None, optional
             Path to the VirtualiZarr file, by default None.
-        virtualizarr_backend : str, optional
-            VirtualiZarr backend, by default "kerchunk".
-        icechunk_repo : str or None, optional
+        use_icechunk : bool, optional
+            Whether to use Icechunk, by default False.
+        icechunk_url : str or None, optional
             Path to the Icechunk repository, by default None.
         use_dask : bool, optional
             Whether to use Dask for lazy loading, by default False.
@@ -70,8 +70,8 @@ class OMPSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_backend=virtualizarr_backend,
-            icechunk_repo=icechunk_repo,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
             use_dask=use_dask,
             **kwargs,
         )

--- a/monetio/readers/ufs.py
+++ b/monetio/readers/ufs.py
@@ -31,6 +31,11 @@ class UFSReader(GriddedReader):
         var_list: list[str] | None = None,
         fname_pm25: str | list[str] | None = None,
         surf_only: bool = False,
+        use_virtualizarr: bool = False,
+        virtualizarr_file: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
+        use_dask: bool = False,
         **kwargs: Any,
     ) -> xr.Dataset:
         """
@@ -50,6 +55,16 @@ class UFSReader(GriddedReader):
             Optional separate PM2.5 files to merge, by default None.
         surf_only : bool, optional
             Whether to only keep surface data, by default False.
+        use_virtualizarr : bool, optional
+            Whether to use VirtualiZarr, by default False.
+        virtualizarr_file : str or None, optional
+            Path to the VirtualiZarr file, by default None.
+        use_icechunk : bool, optional
+            Whether to use Icechunk, by default False.
+        icechunk_url : str or None, optional
+            Path to the Icechunk repository, by default None.
+        use_dask : bool, optional
+            Whether to use Dask for lazy loading, by default False.
         **kwargs : Any
             Additional arguments passed to the driver.
 
@@ -70,7 +85,15 @@ class UFSReader(GriddedReader):
             kwargs["combine"] = "nested"
 
         # Open dataset
-        ds = self.driver.open(files, **kwargs)
+        ds = super().open_dataset(
+            files,
+            use_virtualizarr=use_virtualizarr,
+            virtualizarr_file=virtualizarr_file,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
+            use_dask=use_dask,
+            **kwargs,
+        )
 
         # Merge PM25 file if present
         if fname_pm25 is not None:

--- a/monetio/readers/ufs.py
+++ b/monetio/readers/ufs.py
@@ -33,6 +33,8 @@ class UFSReader(GriddedReader):
         surf_only: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -59,6 +61,10 @@ class UFSReader(GriddedReader):
             Whether to use VirtualiZarr, by default False.
         virtualizarr_file : str or None, optional
             Path to the VirtualiZarr file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
@@ -89,6 +95,8 @@ class UFSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,

--- a/monetio/readers/wrfchem.py
+++ b/monetio/readers/wrfchem.py
@@ -33,6 +33,11 @@ class WRFChemReader(GriddedReader):
         var_list: list[str] | None = None,
         surf_only: bool = False,
         surf_only_nc: bool = False,
+        use_virtualizarr: bool = False,
+        virtualizarr_file: str | None = None,
+        use_icechunk: bool = False,
+        icechunk_url: str | None = None,
+        use_dask: bool = False,
         **kwargs: Any,
     ) -> xr.Dataset:
         """
@@ -52,6 +57,16 @@ class WRFChemReader(GriddedReader):
             Whether to only keep surface data, by default False.
         surf_only_nc : bool, optional
             Whether input data already contains only surface data, by default False.
+        use_virtualizarr : bool, optional
+            Whether to use VirtualiZarr, by default False.
+        virtualizarr_file : str or None, optional
+            Path to the VirtualiZarr file, by default None.
+        use_icechunk : bool, optional
+            Whether to use Icechunk, by default False.
+        icechunk_url : str or None, optional
+            Path to the Icechunk repository, by default None.
+        use_dask : bool, optional
+            Whether to use Dask for lazy loading, by default False.
         **kwargs : Any
             Additional arguments passed to the driver.
 
@@ -59,6 +74,11 @@ class WRFChemReader(GriddedReader):
         -------
         xarray.Dataset
             The processed WRF-Chem dataset.
+
+        Examples
+        --------
+        >>> reader = WRFChemReader()
+        >>> ds = reader.open_dataset("wrfout_d01_*")
         """
         if "preprocess" not in kwargs:
             kwargs["preprocess"] = partial(
@@ -75,12 +95,62 @@ class WRFChemReader(GriddedReader):
         if "concat_dim" not in kwargs:
             kwargs["concat_dim"] = "time"
 
-        ds = self.driver.open(files, **kwargs)
-
-        ds = self.harmonize(ds)
+        # Explicitly pass virtualization parameters to the driver via base class
+        ds = super().open_dataset(
+            files,
+            use_virtualizarr=use_virtualizarr,
+            virtualizarr_file=virtualizarr_file,
+            use_icechunk=use_icechunk,
+            icechunk_url=icechunk_url,
+            use_dask=use_dask,
+            **kwargs,
+        )
 
         # Update history
         ds = update_history(ds, "Read WRF-Chem data.")
+
+        return ds
+
+    def harmonize(self, ds: xr.Dataset) -> xr.Dataset:
+        """
+        Standardize variable names and metadata.
+
+        Parameters
+        ----------
+        ds : xr.Dataset
+            WRF-Chem dataset.
+
+        Returns
+        -------
+        xr.Dataset
+            Harmonized dataset.
+        """
+        # Coordinate and Dimension Renaming (if not already done in preprocess)
+        rename_dict = {
+            "Time": "time",
+            "south_north": "y",
+            "west_east": "x",
+            "XLONG": "longitude",
+            "XLAT": "latitude",
+            "bottom_top": "z",
+            "bottom_top_stag": "z_stag",
+            "soil_layers_stag": "z_soil",
+        }
+        actual_rename = {}
+        for k, v in rename_dict.items():
+            if k in ds.variables or k in ds.dims:
+                if v in ds.dims and k != v:
+                    continue
+                actual_rename[k] = v
+
+        if actual_rename:
+            ds = ds.rename(actual_rename)
+
+        # Scientific Hygiene
+        ds = _scientific_hygiene(ds)
+
+        # Update history
+        ds = update_history(ds, "Harmonized WRF-Chem dataset.")
 
         return ds
 
@@ -172,8 +242,18 @@ def wrfchem_preprocess(
     # 7. Scientific Hygiene
     ds = _scientific_hygiene(ds)
 
+    # 8. Transpose to standard order if dims exist
+    # Ensure all dimensions are accounted for to avoid ValueError
+    target_dims = ["time", "z", "y", "x"]
+    dims = [d for d in target_dims if d in ds.dims]
+    dims += [d for d in ds.dims if d not in target_dims]
+    if dims:
+        ds = ds.transpose(*dims)
+
     # Update history
-    ds = update_history(ds, "Preprocessed WRF-Chem data.")
+    ds = update_history(
+        ds, "Preprocessed WRF-Chem data (renaming, unit conversion, diagnostics, and hygiene)."
+    )
 
     return ds
 

--- a/monetio/readers/wrfchem.py
+++ b/monetio/readers/wrfchem.py
@@ -35,6 +35,8 @@ class WRFChemReader(GriddedReader):
         surf_only_nc: bool = False,
         use_virtualizarr: bool = False,
         virtualizarr_file: str | None = None,
+        virtualizarr_backend: str = "kerchunk",
+        icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
         use_dask: bool = False,
@@ -61,6 +63,10 @@ class WRFChemReader(GriddedReader):
             Whether to use VirtualiZarr, by default False.
         virtualizarr_file : str or None, optional
             Path to the VirtualiZarr file, by default None.
+        virtualizarr_backend : str, optional
+            VirtualiZarr backend, by default "kerchunk".
+        icechunk_repo : str or None, optional
+            Path to the Icechunk repository, by default None.
         use_icechunk : bool, optional
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
@@ -100,6 +106,8 @@ class WRFChemReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
+            virtualizarr_backend=virtualizarr_backend,
+            icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
             icechunk_url=icechunk_url,
             use_dask=use_dask,

--- a/tests/test_aero_infrastructure_modern.py
+++ b/tests/test_aero_infrastructure_modern.py
@@ -1,0 +1,53 @@
+import warnings
+
+import pandas as pd
+import xarray as xr
+
+from monetio.readers.drivers import XarrayDriver
+
+
+def test_virtualizarr_deprecated_params(tmp_path):
+    """Verify that deprecated virtualizarr parameters still work with a warning."""
+    fname = tmp_path / "test.nc"
+    xr.Dataset({"a": (("x",), [1.0])}).to_netcdf(fname)
+
+    driver = XarrayDriver()
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        try:
+            driver.open(str(fname), virtualizarr_backend="icechunk", icechunk_repo="some_url")
+        except Exception as e:
+            print(f"DEBUG: driver.open raised {type(e).__name__}: {e}")
+
+        print(f"DEBUG: Captured {len(w)} warnings")
+        for warn in w:
+            print(f"DEBUG: Warning: {warn.message}")
+
+        assert any("deprecated" in str(warn.message) for warn in w)
+
+
+def test_point_reader_use_dask():
+    """Verify use_dask alias in PointReader."""
+    from monetio.readers.base import PointReader
+
+    class MockPointReader(PointReader):
+        def harmonize(self, df):
+            return df
+
+        def to_xarray(self, df, **kwargs):
+            return df
+
+    reader = MockPointReader()
+
+    class MockDriver:
+        def open(self, files, **kwargs):
+            return pd.DataFrame({"a": [1], "lazy": [kwargs.get("lazy", False)]})
+
+    reader.driver = MockDriver()
+
+    df_lazy = reader.open_dataset("dummy", use_dask=True, as_xarray=False)
+    assert bool(df_lazy["lazy"].iloc[0]) is True
+
+    df_eager = reader.open_dataset("dummy", use_dask=False, as_xarray=False)
+    assert bool(df_eager["lazy"].iloc[0]) is False

--- a/tests/test_aero_wrfchem_modern.py
+++ b/tests/test_aero_wrfchem_modern.py
@@ -1,0 +1,83 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from monetio.readers.wrfchem import WRFChemReader
+
+
+def create_synthetic_wrfchem_ds():
+    """Create a synthetic WRF-Chem dataset for modernization testing."""
+    times = pd.date_range("2023-01-01", periods=2, freq="h")
+    times_strings = [t.strftime("%Y-%m-%d_%H:%M:%S") for t in times]
+    times_bytes = np.array([list(s) for s in times_strings], dtype="|S1")
+
+    data_vars = {
+        "Times": (("time", "DateStrLen"), times_bytes),
+        "XLAT": (("time", "south_north", "west_east"), np.zeros((2, 4, 4))),
+        "XLONG": (("time", "south_north", "west_east"), np.zeros((2, 4, 4))),
+        "O3": (
+            ("time", "bottom_top", "south_north", "west_east"),
+            np.ones((2, 2, 4, 4)),
+            {"units": "ppmv"},
+        ),
+    }
+    ds = xr.Dataset(data_vars)
+    ds = ds.set_coords(["XLAT", "XLONG"])
+    return ds
+
+
+@pytest.mark.parametrize("use_dask", [False, True])
+def test_wrfchem_modern_params(use_dask, tmp_path):
+    """Test that WRFChemReader accepts modern parameters and use_dask."""
+    ds_orig = create_synthetic_wrfchem_ds()
+    file_path = tmp_path / "wrfout_modern.nc"
+    ds_orig.to_netcdf(file_path)
+
+    reader = WRFChemReader()
+
+    # Test explicit use_dask parameter instead of chunks={}
+    ds = reader.open_dataset(
+        str(file_path),
+        use_dask=use_dask,
+        use_virtualizarr=False,  # Can't test True without extra deps
+        use_icechunk=False,
+    )
+
+    if use_dask:
+        assert ds.O3.chunks is not None
+    else:
+        assert ds.O3.chunks is None
+
+    assert "time" in ds.coords
+    assert ds.O3.attrs["units"] == "ppbV"
+
+
+def test_wrfchem_dimension_ordering(tmp_path):
+    """Verify standard dimension ordering (time, z, y, x)."""
+    ds_orig = create_synthetic_wrfchem_ds()
+    file_path = tmp_path / "wrfout_dims.nc"
+    ds_orig.to_netcdf(file_path)
+
+    reader = WRFChemReader()
+    ds = reader.open_dataset(str(file_path))
+
+    expected_dims = ("time", "z", "y", "x")
+    assert ds.O3.dims == expected_dims
+
+
+def test_wrfchem_history_provenance(tmp_path):
+    """Verify that history accurately reflects transformations."""
+    ds_orig = create_synthetic_wrfchem_ds()
+    file_path = tmp_path / "wrfout_hist.nc"
+    ds_orig.to_netcdf(file_path)
+
+    reader = WRFChemReader()
+    ds = reader.open_dataset(str(file_path))
+
+    assert "history" in ds.attrs
+    hist = ds.attrs["history"]
+    assert "Preprocessed WRF-Chem data" in hist
+    assert "renaming" in hist
+    assert "unit conversion" in hist
+    assert "hygiene" in hist


### PR DESCRIPTION
This PR modernizes the virtualization and Dask parameters across the entire MONETIO reader infrastructure to align with the Aero Protocol and improve API discoverability.

Key changes:
1.  **Infrastructure Refactor**: Renamed `virtualizarr_backend` to `use_icechunk` and `icechunk_repo` to `icechunk_url` in `base.py` and `drivers.py`.
2.  **API Fallbacks**: Added fallback logic in `XarrayDriver.open` to handle deprecated parameter names while emitting a `FutureWarning`.
3.  **Explicit Reader Signatures**: Updated `open_dataset` signatures for `WRFChemReader`, `CMAQReader`, `CAMxReader`, `ChimereReader`, `OMPSReader`, `UFSReader`, `MODISL2Reader`, and `MOPITTReader` to explicitly include `use_virtualizarr`, `virtualizarr_file`, `use_icechunk`, `icechunk_url`, and `use_dask`.
4.  **WRF-Chem Enhancements**: Added a `harmonize` method to `WRFChemReader` for post-concatenation standardization and refined `wrfchem_preprocess` to ensure standard dimension ordering (`time`, `z`, `y`, `x`) and granular history tracking.
5.  **Dask Consistency**: Added `use_dask` as an alias for `lazy` in `PointReader.open_dataset`.
6.  **CLI/API Sync**: Updated `monetio.virtualize` and the `monetio virtualizarr` CLI command to support the new parameter names and the Icechunk backend.
7.  **Verification**: Added new tests in `tests/test_aero_wrfchem_modern.py` and `tests/test_aero_infrastructure_modern.py` and verified all relevant existing tests. All tests pass on both NumPy and Dask backends.

---
*PR created automatically by Jules for task [11434824760363196489](https://jules.google.com/task/11434824760363196489) started by @bbakernoaa*