### PR TITLE
Optimize Cloud Streaming and Enforce Explicit VirtualiZarr Parsers

### DIFF
--- a/monetio/readers/calipso.py
+++ b/monetio/readers/calipso.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("calipso")
 class CALIPSOReader(GriddedReader):
     """
@@ -75,7 +74,7 @@ class CALIPSOReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -90,7 +89,6 @@ class CALIPSOReader(GriddedReader):
         ds = update_history(ds, "Read CALIPSO L2 data.")
 
         return ds
-
 
 def calipso_preprocess(ds: xr.Dataset, variable_dict: dict | None = None) -> xr.Dataset:
     """

--- a/monetio/readers/calipso.py
+++ b/monetio/readers/calipso.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("calipso")
 class CALIPSOReader(GriddedReader):
     """
@@ -89,6 +90,7 @@ class CALIPSOReader(GriddedReader):
         ds = update_history(ds, "Read CALIPSO L2 data.")
 
         return ds
+
 
 def calipso_preprocess(ds: xr.Dataset, variable_dict: dict | None = None) -> xr.Dataset:
     """

--- a/monetio/readers/camx.py
+++ b/monetio/readers/camx.py
@@ -21,6 +21,7 @@ from .base import (
 from .camx_specs import COARSE, DIAGNOSTICS, FINE, NOY_GAS, POC
 from .sat_utils import update_history
 
+
 @register_reader("camx")
 class CAMxReader(GriddedReader):
     """
@@ -149,6 +150,7 @@ class CAMxReader(GriddedReader):
 
         return ds
 
+
 def camx_preprocess(
     ds: xr.Dataset,
     *,
@@ -218,6 +220,7 @@ def camx_preprocess(
 
     return ds
 
+
 def _predefined_mapping_tables(ds: xr.Dataset) -> xr.Dataset:
     """
     Adds mapping tables for backward compatibility.
@@ -278,6 +281,7 @@ def _predefined_mapping_tables(ds: xr.Dataset) -> xr.Dataset:
     }
     ds = ds.assign_attrs({"mapping_tables": mapping_tables})
     return ds
+
 
 # Legacy aliases for backward compatibility
 fine = FINE

--- a/monetio/readers/camx.py
+++ b/monetio/readers/camx.py
@@ -21,7 +21,6 @@ from .base import (
 from .camx_specs import COARSE, DIAGNOSTICS, FINE, NOY_GAS, POC
 from .sat_utils import update_history
 
-
 @register_reader("camx")
 class CAMxReader(GriddedReader):
     """
@@ -94,7 +93,6 @@ class CAMxReader(GriddedReader):
                 earth_radius=earth_radius,
                 convert_to_ppb=convert_to_ppb,
             )
-
         # 2. Open the dataset using standard xarray (via XarrayDriver)
         if "combine" not in kwargs:
             kwargs["combine"] = "nested"
@@ -105,7 +103,7 @@ class CAMxReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -150,7 +148,6 @@ class CAMxReader(GriddedReader):
         ds = update_history(ds, "Harmonized CAMx dataset.")
 
         return ds
-
 
 def camx_preprocess(
     ds: xr.Dataset,
@@ -221,7 +218,6 @@ def camx_preprocess(
 
     return ds
 
-
 def _predefined_mapping_tables(ds: xr.Dataset) -> xr.Dataset:
     """
     Adds mapping tables for backward compatibility.
@@ -282,7 +278,6 @@ def _predefined_mapping_tables(ds: xr.Dataset) -> xr.Dataset:
     }
     ds = ds.assign_attrs({"mapping_tables": mapping_tables})
     return ds
-
 
 # Legacy aliases for backward compatibility
 fine = FINE

--- a/monetio/readers/chimere.py
+++ b/monetio/readers/chimere.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import update_history
 
-
 @register_reader("chimere")
 class ChimereReader(GriddedReader):
     """
@@ -87,7 +86,7 @@ class ChimereReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -102,7 +101,6 @@ class ChimereReader(GriddedReader):
         ds = update_history(ds, "Read Chimere data.")
 
         return ds
-
 
 def chimere_preprocess(
     ds: xr.Dataset, *, var_list: list[str] | None = None, surf_only: bool = False

--- a/monetio/readers/chimere.py
+++ b/monetio/readers/chimere.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import update_history
 
+
 @register_reader("chimere")
 class ChimereReader(GriddedReader):
     """
@@ -101,6 +102,7 @@ class ChimereReader(GriddedReader):
         ds = update_history(ds, "Read Chimere data.")
 
         return ds
+
 
 def chimere_preprocess(
     ds: xr.Dataset, *, var_list: list[str] | None = None, surf_only: bool = False

--- a/monetio/readers/cmaq.py
+++ b/monetio/readers/cmaq.py
@@ -21,6 +21,7 @@ from .base import (
 from .cmaq_specs import DIAGNOSTICS
 from .sat_utils import update_history
 
+
 @register_reader("cmaq")
 class CMAQReader(GriddedReader):
     """
@@ -146,6 +147,7 @@ class CMAQReader(GriddedReader):
         ds = update_history(ds, "Harmonized CMAQ dataset.")
 
         return ds
+
 
 def cmaq_preprocess(
     ds: xr.Dataset,

--- a/monetio/readers/cmaq.py
+++ b/monetio/readers/cmaq.py
@@ -21,7 +21,6 @@ from .base import (
 from .cmaq_specs import DIAGNOSTICS
 from .sat_utils import update_history
 
-
 @register_reader("cmaq")
 class CMAQReader(GriddedReader):
     """
@@ -88,7 +87,6 @@ class CMAQReader(GriddedReader):
                 earth_radius=earth_radius,
                 convert_to_ppb=convert_to_ppb,
             )
-
         # 2. Open the dataset using standard xarray (via XarrayDriver)
         if "combine" not in kwargs:
             kwargs["combine"] = "nested"
@@ -103,7 +101,7 @@ class CMAQReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -148,7 +146,6 @@ class CMAQReader(GriddedReader):
         ds = update_history(ds, "Harmonized CMAQ dataset.")
 
         return ds
-
 
 def cmaq_preprocess(
     ds: xr.Dataset,

--- a/monetio/readers/drivers.py
+++ b/monetio/readers/drivers.py
@@ -335,6 +335,7 @@ class XarrayDriver:
                 registry, file_list = _select_store(file_list, storage_options)
 
                 concat_dim = xr_kwargs.get("concat_dim", "time")
+                parallel_sweep = xr_kwargs.get("parallel", True)
                 try:
                     vds = open_virtual_mfdataset(
                         file_list,
@@ -342,10 +343,17 @@ class XarrayDriver:
                         parser=parser,
                         combine="nested",
                         concat_dim=concat_dim,
+                        parallel=parallel_sweep,
+                        loadable_variables=[],
                     )
                 except ValueError:
                     vds = open_virtual_mfdataset(
-                        file_list, registry=registry, parser=parser, combine="by_coords"
+                        file_list,
+                        registry=registry,
+                        parser=parser,
+                        combine="by_coords",
+                        parallel=parallel_sweep,
+                        loadable_variables=[],
                     )
 
                 # --- Branch on backend ---

--- a/monetio/readers/earlinet.py
+++ b/monetio/readers/earlinet.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
-
 @register_reader("earlinet")
 class EARLINETReader(GriddedReader):
     """
@@ -64,7 +63,7 @@ class EARLINETReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -75,7 +74,6 @@ class EARLINETReader(GriddedReader):
         )
 
         return ds
-
 
 def earlinet_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/earlinet.py
+++ b/monetio/readers/earlinet.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
+
 @register_reader("earlinet")
 class EARLINETReader(GriddedReader):
     """
@@ -74,6 +75,7 @@ class EARLINETReader(GriddedReader):
         )
 
         return ds
+
 
 def earlinet_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/earthcare.py
+++ b/monetio/readers/earthcare.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("earthcare")
 class EarthCAREReader(GriddedReader):
     """
@@ -69,7 +68,7 @@ class EarthCAREReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -84,7 +83,6 @@ class EarthCAREReader(GriddedReader):
         ds = update_history(ds, "Read EarthCARE L2 data.")
 
         return ds
-
 
 def earthcare_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/earthcare.py
+++ b/monetio/readers/earthcare.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("earthcare")
 class EarthCAREReader(GriddedReader):
     """
@@ -83,6 +84,7 @@ class EarthCAREReader(GriddedReader):
         ds = update_history(ds, "Read EarthCARE L2 data.")
 
         return ds
+
 
 def earthcare_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/eprofile.py
+++ b/monetio/readers/eprofile.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
-
 @register_reader("eprofile")
 class EPROFILEReader(GriddedReader):
     """
@@ -75,7 +74,7 @@ class EPROFILEReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -86,7 +85,6 @@ class EPROFILEReader(GriddedReader):
         )
 
         return ds
-
 
 def eprofile_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/eprofile.py
+++ b/monetio/readers/eprofile.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
+
 @register_reader("eprofile")
 class EPROFILEReader(GriddedReader):
     """
@@ -85,6 +86,7 @@ class EPROFILEReader(GriddedReader):
         )
 
         return ds
+
 
 def eprofile_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/era5.py
+++ b/monetio/readers/era5.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("era5")
 class ERA5Reader(GriddedReader):
     """
@@ -58,12 +57,11 @@ class ERA5Reader(GriddedReader):
         """
         if "preprocess" not in kwargs:
             kwargs["preprocess"] = era5_preprocess
-
         ds = super().open_dataset(
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -76,7 +74,6 @@ class ERA5Reader(GriddedReader):
         ds = update_history(ds, "Read ERA5 data.")
 
         return ds
-
 
 def era5_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/era5.py
+++ b/monetio/readers/era5.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("era5")
 class ERA5Reader(GriddedReader):
     """
@@ -74,6 +75,7 @@ class ERA5Reader(GriddedReader):
         ds = update_history(ds, "Read ERA5 data.")
 
         return ds
+
 
 def era5_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/gems.py
+++ b/monetio/readers/gems.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("gems")
 class GEMSReader(GriddedReader):
     """
@@ -134,6 +135,7 @@ class GEMSReader(GriddedReader):
         ds = update_history(ds, "Read GEMS L2 data.")
 
         return ds
+
 
 def gems_preprocess(ds: xr.Dataset, variable_dict: dict | None = None) -> xr.Dataset:
     """

--- a/monetio/readers/gems.py
+++ b/monetio/readers/gems.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("gems")
 class GEMSReader(GriddedReader):
     """
@@ -91,7 +90,7 @@ class GEMSReader(GriddedReader):
                     files,
                     use_virtualizarr=use_virtualizarr,
                     virtualizarr_file=virtualizarr_file,
-                    virtualizarr_parser=virtualizarr_parser,
+                    virtualizarr_parser="hdf5",
                     virtualizarr_backend=virtualizarr_backend,
                     icechunk_repo=icechunk_repo,
                     use_icechunk=use_icechunk,
@@ -111,7 +110,7 @@ class GEMSReader(GriddedReader):
                     files,
                     use_virtualizarr=use_virtualizarr,
                     virtualizarr_file=virtualizarr_file,
-                    virtualizarr_parser=virtualizarr_parser,
+                    virtualizarr_parser="hdf5",
                     virtualizarr_backend=virtualizarr_backend,
                     icechunk_repo=icechunk_repo,
                     use_icechunk=use_icechunk,
@@ -135,7 +134,6 @@ class GEMSReader(GriddedReader):
         ds = update_history(ds, "Read GEMS L2 data.")
 
         return ds
-
 
 def gems_preprocess(ds: xr.Dataset, variable_dict: dict | None = None) -> xr.Dataset:
     """

--- a/monetio/readers/geoms.py
+++ b/monetio/readers/geoms.py
@@ -11,7 +11,6 @@ from .base import GriddedReader, register_reader
 from .drivers import FileUtility
 from .sat_utils import update_history
 
-
 @register_reader("geoms")
 class GEOMSReader(GriddedReader):
     """
@@ -97,7 +96,6 @@ class GEOMSReader(GriddedReader):
 
         return ds
 
-
 def open_dataset_geoms(fp: str, *, rename_all: bool = True, squeeze: bool = True) -> xr.Dataset:
     """
     Internal function to open a single GEOMS file.
@@ -168,7 +166,6 @@ def open_dataset_geoms(fp: str, *, rename_all: bool = True, squeeze: bool = True
     ds = geoms_preprocess(ds, rename_all=rename_all, squeeze=squeeze)
 
     return ds
-
 
 def geoms_preprocess(
     ds: xr.Dataset, *, rename_all: bool = True, squeeze: bool = True
@@ -270,7 +267,6 @@ def geoms_preprocess(
 
     return ds
 
-
 def _handle_strings(ds: xr.Dataset) -> xr.Dataset:
     """
     Decodes byte strings and handles object-type strings lazily.
@@ -302,7 +298,6 @@ def _handle_strings(ds: xr.Dataset) -> xr.Dataset:
             ds[vn] = decoded.astype(str)
     return ds
 
-
 def _decode_obj(x: Any) -> str:
     """
     Helper to decode object that might be bytes.
@@ -320,7 +315,6 @@ def _decode_obj(x: Any) -> str:
     if isinstance(x, bytes):
         return x.decode("utf-8")
     return str(x)
-
 
 def _convert_times_lazy(ds: xr.Dataset) -> xr.Dataset:
     """
@@ -350,7 +344,6 @@ def _convert_times_lazy(ds: xr.Dataset) -> xr.Dataset:
             )
     return ds
 
-
 def _mjd2000_to_datetime(x: np.ndarray) -> np.ndarray:
     """
     Vectorized conversion from MJD2000 to datetime64[ns].
@@ -379,7 +372,6 @@ def _mjd2000_to_datetime(x: np.ndarray) -> np.ndarray:
     # when possible, though apply_ufunc will pass numpy arrays here anyway.
     return pd.to_datetime(jd, unit="D", origin="julian").to_numpy().astype("datetime64[ns]")
 
-
 def _read_hdf4(
     sd: Any,
 ) -> tuple[dict[str, tuple[tuple[str, ...], np.ndarray, dict[str, Any]]], dict[str, Any]]:
@@ -407,7 +399,6 @@ def _read_hdf4(
     attrs = sd.attributes()
     return data_vars, attrs
 
-
 def _rename_h5_dim(s: str) -> str:
     """
     Parses HDF5 dimension label.
@@ -432,7 +423,6 @@ def _rename_h5_dim(s: str) -> str:
     label, num, _ = m.groups()
     return f"fakeDim{num}{label}"
 
-
 def _rename_var(vn: str, *, under: str = "_", dot: str = "_") -> str:
     """
     Standardizes variable names.
@@ -452,7 +442,6 @@ def _rename_var(vn: str, *, under: str = "_", dot: str = "_") -> str:
         Standardized name.
     """
     return vn.lower().replace("_", under).replace(".", dot)
-
 
 def _dti_from_mjd2000(x: Any) -> pd.DatetimeIndex:
     """

--- a/monetio/readers/geoms.py
+++ b/monetio/readers/geoms.py
@@ -11,6 +11,7 @@ from .base import GriddedReader, register_reader
 from .drivers import FileUtility
 from .sat_utils import update_history
 
+
 @register_reader("geoms")
 class GEOMSReader(GriddedReader):
     """
@@ -96,6 +97,7 @@ class GEOMSReader(GriddedReader):
 
         return ds
 
+
 def open_dataset_geoms(fp: str, *, rename_all: bool = True, squeeze: bool = True) -> xr.Dataset:
     """
     Internal function to open a single GEOMS file.
@@ -166,6 +168,7 @@ def open_dataset_geoms(fp: str, *, rename_all: bool = True, squeeze: bool = True
     ds = geoms_preprocess(ds, rename_all=rename_all, squeeze=squeeze)
 
     return ds
+
 
 def geoms_preprocess(
     ds: xr.Dataset, *, rename_all: bool = True, squeeze: bool = True
@@ -267,6 +270,7 @@ def geoms_preprocess(
 
     return ds
 
+
 def _handle_strings(ds: xr.Dataset) -> xr.Dataset:
     """
     Decodes byte strings and handles object-type strings lazily.
@@ -298,6 +302,7 @@ def _handle_strings(ds: xr.Dataset) -> xr.Dataset:
             ds[vn] = decoded.astype(str)
     return ds
 
+
 def _decode_obj(x: Any) -> str:
     """
     Helper to decode object that might be bytes.
@@ -315,6 +320,7 @@ def _decode_obj(x: Any) -> str:
     if isinstance(x, bytes):
         return x.decode("utf-8")
     return str(x)
+
 
 def _convert_times_lazy(ds: xr.Dataset) -> xr.Dataset:
     """
@@ -344,6 +350,7 @@ def _convert_times_lazy(ds: xr.Dataset) -> xr.Dataset:
             )
     return ds
 
+
 def _mjd2000_to_datetime(x: np.ndarray) -> np.ndarray:
     """
     Vectorized conversion from MJD2000 to datetime64[ns].
@@ -372,6 +379,7 @@ def _mjd2000_to_datetime(x: np.ndarray) -> np.ndarray:
     # when possible, though apply_ufunc will pass numpy arrays here anyway.
     return pd.to_datetime(jd, unit="D", origin="julian").to_numpy().astype("datetime64[ns]")
 
+
 def _read_hdf4(
     sd: Any,
 ) -> tuple[dict[str, tuple[tuple[str, ...], np.ndarray, dict[str, Any]]], dict[str, Any]]:
@@ -399,6 +407,7 @@ def _read_hdf4(
     attrs = sd.attributes()
     return data_vars, attrs
 
+
 def _rename_h5_dim(s: str) -> str:
     """
     Parses HDF5 dimension label.
@@ -423,6 +432,7 @@ def _rename_h5_dim(s: str) -> str:
     label, num, _ = m.groups()
     return f"fakeDim{num}{label}"
 
+
 def _rename_var(vn: str, *, under: str = "_", dot: str = "_") -> str:
     """
     Standardizes variable names.
@@ -442,6 +452,7 @@ def _rename_var(vn: str, *, under: str = "_", dot: str = "_") -> str:
         Standardized name.
     """
     return vn.lower().replace("_", under).replace(".", dot)
+
 
 def _dti_from_mjd2000(x: Any) -> pd.DatetimeIndex:
     """

--- a/monetio/readers/goes.py
+++ b/monetio/readers/goes.py
@@ -9,7 +9,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import add_time_coord, standardize_satellite_coords, update_history
 
-
 @register_reader("goes")
 class GOESReader(GriddedReader):
     """
@@ -80,12 +79,11 @@ class GOESReader(GriddedReader):
 
         if "engine" not in kwargs:
             kwargs["engine"] = "h5netcdf"
-
         ds = super().open_dataset(
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -175,7 +173,6 @@ class GOESReader(GriddedReader):
 
         return sorted(list(set(urls)))
 
-
 def goes_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """
     Preprocess GOES dataset: calculate grid and standardize coordinates.
@@ -210,7 +207,6 @@ def goes_preprocess(ds: xr.Dataset) -> xr.Dataset:
     ds = update_history(ds, "Preprocessed GOES data.")
 
     return ds
-
 
 def _add_goes_latlon(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/goes.py
+++ b/monetio/readers/goes.py
@@ -9,6 +9,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import add_time_coord, standardize_satellite_coords, update_history
 
+
 @register_reader("goes")
 class GOESReader(GriddedReader):
     """
@@ -173,6 +174,7 @@ class GOESReader(GriddedReader):
 
         return sorted(list(set(urls)))
 
+
 def goes_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """
     Preprocess GOES dataset: calculate grid and standardize coordinates.
@@ -207,6 +209,7 @@ def goes_preprocess(ds: xr.Dataset) -> xr.Dataset:
     ds = update_history(ds, "Preprocessed GOES data.")
 
     return ds
+
 
 def _add_goes_latlon(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/gpm_imerg.py
+++ b/monetio/readers/gpm_imerg.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("gpm_imerg")
 class GPMIMERGReader(GriddedReader):
     """
@@ -156,6 +157,7 @@ class GPMIMERGReader(GriddedReader):
             urls.append(url)
 
         return urls
+
 
 def gpm_imerg_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/gpm_imerg.py
+++ b/monetio/readers/gpm_imerg.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("gpm_imerg")
 class GPMIMERGReader(GriddedReader):
     """
@@ -81,12 +80,11 @@ class GPMIMERGReader(GriddedReader):
         # GPM IMERG HDF5 files often need the h5netcdf engine
         if "engine" not in kwargs:
             kwargs["engine"] = "h5netcdf"
-
         ds = super().open_dataset(
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -158,7 +156,6 @@ class GPMIMERGReader(GriddedReader):
             urls.append(url)
 
         return urls
-
 
 def gpm_imerg_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/grib2.py
+++ b/monetio/readers/grib2.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
+
 @register_reader("grib2")
 class Grib2Reader(GriddedReader):
     """

--- a/monetio/readers/grib2.py
+++ b/monetio/readers/grib2.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
-
 @register_reader("grib2")
 class Grib2Reader(GriddedReader):
     """
@@ -64,7 +63,6 @@ class Grib2Reader(GriddedReader):
         """
         if "engine" not in kwargs:
             kwargs["engine"] = engine
-
         if filters is not None and "backend_kwargs" not in kwargs:
             kwargs["backend_kwargs"] = {"filters": filters}
 
@@ -74,7 +72,7 @@ class Grib2Reader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="grib2",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,

--- a/monetio/readers/hysplit.py
+++ b/monetio/readers/hysplit.py
@@ -10,6 +10,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader, update_history
 from .drivers import FileUtility
 
+
 @register_reader("hysplit")
 class HYSPLITReader(GriddedReader):
     def open_dataset(
@@ -112,9 +113,11 @@ class HYSPLITReader(GriddedReader):
     def harmonize(self, ds):
         return ds
 
+
 # -----------------------------------------------------------------------------
 # HYSPLIT Core Logic Ported
 # -----------------------------------------------------------------------------
+
 
 def open_dataset_hysplit(
     fname,
@@ -137,6 +140,7 @@ def open_dataset_hysplit(
         return fix_grid_continuity(dset)
     else:
         return dset
+
 
 class ModelBin:
     def __init__(
@@ -459,6 +463,7 @@ class ModelBin:
             return False
         return True
 
+
 def check_drange(drange, pdate1, pdate2):
     savedata = True
     testf = True
@@ -472,6 +477,7 @@ def check_drange(drange, pdate1, pdate2):
     else:
         savedata = False
     return testf, savedata
+
 
 def fix_grid_continuity(dset: xr.Dataset) -> xr.Dataset:
     """
@@ -510,6 +516,7 @@ def fix_grid_continuity(dset: xr.Dataset) -> xr.Dataset:
 
     return dset
 
+
 def check_grid_continuity(dset: xr.Dataset) -> bool:
     """
     Check if the grid indices x and y are continuous (step of 1).
@@ -532,6 +539,7 @@ def check_grid_continuity(dset: xr.Dataset) -> bool:
         if not (dset.y.diff("y") == 1).all():
             return False
     return True
+
 
 def get_latlongrid(attrs: dict, xindx: np.ndarray, yindx: np.ndarray) -> list[np.ndarray]:
     """
@@ -571,6 +579,7 @@ def get_latlongrid(attrs: dict, xindx: np.ndarray, yindx: np.ndarray) -> list[np
     # Return as numpy-like data to match expected signature
     return [lon_2d.transpose("y", "x").data, lat_2d.transpose("y", "x").data]
 
+
 def getlatlon(attrs: dict) -> tuple[np.ndarray, np.ndarray]:
     """
     Generate 1D latitude and longitude arrays from HYSPLIT attributes.
@@ -601,6 +610,7 @@ def getlatlon(attrs: dict) -> tuple[np.ndarray, np.ndarray]:
     lon = np.where(lon >= 180 + lon_tolerance, lon - 360, lon)
 
     return lat, lon
+
 
 def combine_dataset(
     blist,
@@ -712,6 +722,7 @@ def combine_dataset(
 
     return rval
 
+
 def add_species(dset: xr.Dataset, species: list[str] = None) -> xr.Dataset:
     """
     Sum multiple species into a single DataArray/Dataset.
@@ -748,6 +759,7 @@ def add_species(dset: xr.Dataset, species: list[str] = None) -> xr.Dataset:
     res.attrs["Species ID"] = sflist
     return update_history(res, f"Added species sum: {sflist}")
 
+
 def reset_latlon_coords(hxr):
     mgrid = get_latlongrid(hxr.attrs, hxr.x, hxr.y)
     if "latitude" in hxr.coords:
@@ -759,9 +771,11 @@ def reset_latlon_coords(hxr):
     hxr = update_history(hxr, "Reset lat/lon coordinates.")
     return hxr
 
+
 # -----------------------------------------------------------------------------
 # HYSPLIT Exporter / Utility Ported from cdump2netcdf.py
 # -----------------------------------------------------------------------------
+
 
 def thickness_hash(xrash: xr.Dataset | xr.DataArray) -> dict:
     """
@@ -783,6 +797,7 @@ def thickness_hash(xrash: xr.Dataset | xr.DataArray) -> dict:
     xlevs = xrash.z.data
     dhash = dict(zip(xlevs, delta.data))
     return dhash
+
 
 def get_thickness(xrash: xr.Dataset | xr.DataArray) -> xr.DataArray:
     """
@@ -807,6 +822,7 @@ def get_thickness(xrash: xr.Dataset | xr.DataArray) -> xr.DataArray:
     delta = z - z_prev
     return delta.rename("thickness")
 
+
 def remove_dep(xrash: xr.Dataset | xr.DataArray) -> xr.Dataset | xr.DataArray:
     """
     Mask the deposition layer (z=0) if present backend-agnostic.
@@ -823,6 +839,7 @@ def remove_dep(xrash: xr.Dataset | xr.DataArray) -> xr.Dataset | xr.DataArray:
         Data with deposition layer masked.
     """
     return xrash.where(xrash.z > 0)
+
 
 def mass_loading(
     xrash: xr.DataArray | xr.Dataset, delta: xr.DataArray | np.ndarray | None = None
@@ -883,6 +900,7 @@ def mass_loading(
             ml = update_history(ml, "Calculated mass loading using standardized preprocessing.")
 
     return ml
+
 
 def cdump2awips(xrash1, dt, outname, mscale=1, munit="unit", format="NETCDF4"):
     from netCDF4 import Dataset

--- a/monetio/readers/hysplit.py
+++ b/monetio/readers/hysplit.py
@@ -10,7 +10,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader, update_history
 from .drivers import FileUtility
 
-
 @register_reader("hysplit")
 class HYSPLITReader(GriddedReader):
     def open_dataset(
@@ -94,7 +93,7 @@ class HYSPLITReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -113,11 +112,9 @@ class HYSPLITReader(GriddedReader):
     def harmonize(self, ds):
         return ds
 
-
 # -----------------------------------------------------------------------------
 # HYSPLIT Core Logic Ported
 # -----------------------------------------------------------------------------
-
 
 def open_dataset_hysplit(
     fname,
@@ -140,7 +137,6 @@ def open_dataset_hysplit(
         return fix_grid_continuity(dset)
     else:
         return dset
-
 
 class ModelBin:
     def __init__(
@@ -463,7 +459,6 @@ class ModelBin:
             return False
         return True
 
-
 def check_drange(drange, pdate1, pdate2):
     savedata = True
     testf = True
@@ -477,7 +472,6 @@ def check_drange(drange, pdate1, pdate2):
     else:
         savedata = False
     return testf, savedata
-
 
 def fix_grid_continuity(dset: xr.Dataset) -> xr.Dataset:
     """
@@ -516,7 +510,6 @@ def fix_grid_continuity(dset: xr.Dataset) -> xr.Dataset:
 
     return dset
 
-
 def check_grid_continuity(dset: xr.Dataset) -> bool:
     """
     Check if the grid indices x and y are continuous (step of 1).
@@ -539,7 +532,6 @@ def check_grid_continuity(dset: xr.Dataset) -> bool:
         if not (dset.y.diff("y") == 1).all():
             return False
     return True
-
 
 def get_latlongrid(attrs: dict, xindx: np.ndarray, yindx: np.ndarray) -> list[np.ndarray]:
     """
@@ -579,7 +571,6 @@ def get_latlongrid(attrs: dict, xindx: np.ndarray, yindx: np.ndarray) -> list[np
     # Return as numpy-like data to match expected signature
     return [lon_2d.transpose("y", "x").data, lat_2d.transpose("y", "x").data]
 
-
 def getlatlon(attrs: dict) -> tuple[np.ndarray, np.ndarray]:
     """
     Generate 1D latitude and longitude arrays from HYSPLIT attributes.
@@ -610,7 +601,6 @@ def getlatlon(attrs: dict) -> tuple[np.ndarray, np.ndarray]:
     lon = np.where(lon >= 180 + lon_tolerance, lon - 360, lon)
 
     return lat, lon
-
 
 def combine_dataset(
     blist,
@@ -722,7 +712,6 @@ def combine_dataset(
 
     return rval
 
-
 def add_species(dset: xr.Dataset, species: list[str] = None) -> xr.Dataset:
     """
     Sum multiple species into a single DataArray/Dataset.
@@ -759,7 +748,6 @@ def add_species(dset: xr.Dataset, species: list[str] = None) -> xr.Dataset:
     res.attrs["Species ID"] = sflist
     return update_history(res, f"Added species sum: {sflist}")
 
-
 def reset_latlon_coords(hxr):
     mgrid = get_latlongrid(hxr.attrs, hxr.x, hxr.y)
     if "latitude" in hxr.coords:
@@ -771,11 +759,9 @@ def reset_latlon_coords(hxr):
     hxr = update_history(hxr, "Reset lat/lon coordinates.")
     return hxr
 
-
 # -----------------------------------------------------------------------------
 # HYSPLIT Exporter / Utility Ported from cdump2netcdf.py
 # -----------------------------------------------------------------------------
-
 
 def thickness_hash(xrash: xr.Dataset | xr.DataArray) -> dict:
     """
@@ -797,7 +783,6 @@ def thickness_hash(xrash: xr.Dataset | xr.DataArray) -> dict:
     xlevs = xrash.z.data
     dhash = dict(zip(xlevs, delta.data))
     return dhash
-
 
 def get_thickness(xrash: xr.Dataset | xr.DataArray) -> xr.DataArray:
     """
@@ -822,7 +807,6 @@ def get_thickness(xrash: xr.Dataset | xr.DataArray) -> xr.DataArray:
     delta = z - z_prev
     return delta.rename("thickness")
 
-
 def remove_dep(xrash: xr.Dataset | xr.DataArray) -> xr.Dataset | xr.DataArray:
     """
     Mask the deposition layer (z=0) if present backend-agnostic.
@@ -839,7 +823,6 @@ def remove_dep(xrash: xr.Dataset | xr.DataArray) -> xr.Dataset | xr.DataArray:
         Data with deposition layer masked.
     """
     return xrash.where(xrash.z > 0)
-
 
 def mass_loading(
     xrash: xr.DataArray | xr.Dataset, delta: xr.DataArray | np.ndarray | None = None
@@ -900,7 +883,6 @@ def mass_loading(
             ml = update_history(ml, "Calculated mass loading using standardized preprocessing.")
 
     return ml
-
 
 def cdump2awips(xrash1, dt, outname, mscale=1, munit="unit", format="NETCDF4"):
     from netCDF4 import Dataset

--- a/monetio/readers/icap_mme.py
+++ b/monetio/readers/icap_mme.py
@@ -21,7 +21,6 @@ VALID_DATA_VARS = (
     "totaldustaod550",
 )
 
-
 @register_reader("icap_mme")
 class ICAPMMEReader(GriddedReader):
     """
@@ -122,7 +121,7 @@ class ICAPMMEReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -137,7 +136,6 @@ class ICAPMMEReader(GriddedReader):
         ds = update_history(ds, "Read ICAP-MME data.")
 
         return ds
-
 
 def build_urls(
     dates: pd.DatetimeIndex | list[datetime] | datetime | str,
@@ -190,7 +188,6 @@ def build_urls(
         fnames.append(fname)
 
     return urls, fnames
-
 
 def retrieve(url: str, fname: str, download: bool = False, verbose: bool = True) -> str | Path:
     """

--- a/monetio/readers/icap_mme.py
+++ b/monetio/readers/icap_mme.py
@@ -21,6 +21,7 @@ VALID_DATA_VARS = (
     "totaldustaod550",
 )
 
+
 @register_reader("icap_mme")
 class ICAPMMEReader(GriddedReader):
     """
@@ -137,6 +138,7 @@ class ICAPMMEReader(GriddedReader):
 
         return ds
 
+
 def build_urls(
     dates: pd.DatetimeIndex | list[datetime] | datetime | str,
     filetype: str = "MMC",
@@ -188,6 +190,7 @@ def build_urls(
         fnames.append(fname)
 
     return urls, fnames
+
 
 def retrieve(url: str, fname: str, download: bool = False, verbose: bool = True) -> str | Path:
     """

--- a/monetio/readers/jpss_atms.py
+++ b/monetio/readers/jpss_atms.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("jpss_atms")
 class JPSSATMSReader(GriddedReader):
     """
@@ -79,6 +80,7 @@ class JPSSATMSReader(GriddedReader):
         ds = update_history(ds, "Read JPSS ATMS meteorological profile data.")
 
         return ds
+
 
 def jpss_atms_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/jpss_atms.py
+++ b/monetio/readers/jpss_atms.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("jpss_atms")
 class JPSSATMSReader(GriddedReader):
     """
@@ -67,7 +66,7 @@ class JPSSATMSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -80,7 +79,6 @@ class JPSSATMSReader(GriddedReader):
         ds = update_history(ds, "Read JPSS ATMS meteorological profile data.")
 
         return ds
-
 
 def jpss_atms_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/jpss_cris.py
+++ b/monetio/readers/jpss_cris.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("jpss_cris")
 class JPSSCrISReader(GriddedReader):
     """
@@ -67,7 +66,7 @@ class JPSSCrISReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -80,7 +79,6 @@ class JPSSCrISReader(GriddedReader):
         ds = update_history(ds, "Read JPSS CrIS meteorological profile data.")
 
         return ds
-
 
 def jpss_cris_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/jpss_cris.py
+++ b/monetio/readers/jpss_cris.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("jpss_cris")
 class JPSSCrISReader(GriddedReader):
     """
@@ -79,6 +80,7 @@ class JPSSCrISReader(GriddedReader):
         ds = update_history(ds, "Read JPSS CrIS meteorological profile data.")
 
         return ds
+
 
 def jpss_cris_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/merra2.py
+++ b/monetio/readers/merra2.py
@@ -9,6 +9,7 @@ from .base import GriddedReader, _scientific_hygiene, register_reader
 from .nasa_utils import setup_netrc
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("merra2")
 class MERRA2Reader(GriddedReader):
     """
@@ -207,6 +208,7 @@ class MERRA2Reader(GriddedReader):
 
         return urls
 
+
 def merra2_preprocess(ds: xr.Dataset, product: str | None = None) -> xr.Dataset:
     """
     Preprocess MERRA-2 dataset: standardize coordinates and metadata.
@@ -277,6 +279,7 @@ def merra2_preprocess(ds: xr.Dataset, product: str | None = None) -> xr.Dataset:
     ds = update_history(ds, "Preprocessed MERRA-2 data using standardized preprocessing.")
 
     return ds
+
 
 def _add_merra2_pressure(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/merra2.py
+++ b/monetio/readers/merra2.py
@@ -9,7 +9,6 @@ from .base import GriddedReader, _scientific_hygiene, register_reader
 from .nasa_utils import setup_netrc
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("merra2")
 class MERRA2Reader(GriddedReader):
     """
@@ -93,12 +92,11 @@ class MERRA2Reader(GriddedReader):
 
         if virtualizarr is not None:
             kwargs["virtualizarr_file"] = virtualizarr
-
         ds = super().open_dataset(
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -209,7 +207,6 @@ class MERRA2Reader(GriddedReader):
 
         return urls
 
-
 def merra2_preprocess(ds: xr.Dataset, product: str | None = None) -> xr.Dataset:
     """
     Preprocess MERRA-2 dataset: standardize coordinates and metadata.
@@ -280,7 +277,6 @@ def merra2_preprocess(ds: xr.Dataset, product: str | None = None) -> xr.Dataset:
     ds = update_history(ds, "Preprocessed MERRA-2 data using standardized preprocessing.")
 
     return ds
-
 
 def _add_merra2_pressure(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/modis_l2.py
+++ b/monetio/readers/modis_l2.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, tai93_to_datetime, update_history
 
-
 @register_reader("modis_l2")
 class MODISL2Reader(GriddedReader):
     """
@@ -81,7 +80,7 @@ class MODISL2Reader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -103,7 +102,6 @@ class MODISL2Reader(GriddedReader):
         ds = update_history(ds, "Read MODIS L2 data.")
 
         return ds
-
 
 def modis_l2_preprocess(ds: xr.Dataset, variable_dict: dict = None) -> xr.Dataset:
     """

--- a/monetio/readers/modis_l2.py
+++ b/monetio/readers/modis_l2.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, tai93_to_datetime, update_history
 
+
 @register_reader("modis_l2")
 class MODISL2Reader(GriddedReader):
     """
@@ -102,6 +103,7 @@ class MODISL2Reader(GriddedReader):
         ds = update_history(ds, "Read MODIS L2 data.")
 
         return ds
+
 
 def modis_l2_preprocess(ds: xr.Dataset, variable_dict: dict = None) -> xr.Dataset:
     """

--- a/monetio/readers/modis_ornl.py
+++ b/monetio/readers/modis_ornl.py
@@ -18,6 +18,7 @@ except ImportError:
 
 DEFAULT_WSDL = "https://modis.ornl.gov/cgi-bin/MODIS/soapservice/MODIS_soapservice.wsdl"
 
+
 @register_reader("modis_ornl")
 class MODISORNLReader(GriddedReader):
     """
@@ -93,6 +94,7 @@ class MODISORNLReader(GriddedReader):
 
         return ds
 
+
 def _nearest(items: pd.DatetimeIndex, pivot: pd.Timestamp) -> pd.Timestamp:
     """
     Find the nearest date in a list.
@@ -110,6 +112,7 @@ def _nearest(items: pd.DatetimeIndex, pivot: pd.Timestamp) -> pd.Timestamp:
         The nearest date.
     """
     return min(items, key=lambda x: abs(x - pivot))
+
 
 def _get_single_retrieval(
     date: pd.Timestamp,
@@ -194,6 +197,7 @@ def _get_single_retrieval(
 
     return ds
 
+
 def _make_xarray_dataset(grid_data: np.ndarray, metadata: dict) -> xr.Dataset:
     """
     Create an xarray Dataset from raw data and metadata.
@@ -238,6 +242,7 @@ def _make_xarray_dataset(grid_data: np.ndarray, metadata: dict) -> xr.Dataset:
     ds = update_history(ds, "Created xarray Dataset from MODIS ORNL subset.")
 
     return ds
+
 
 def _get_latlon(
     xll: float, yll: float, cell_width: float, nx: int, ny: int

--- a/monetio/readers/modis_ornl.py
+++ b/monetio/readers/modis_ornl.py
@@ -18,7 +18,6 @@ except ImportError:
 
 DEFAULT_WSDL = "https://modis.ornl.gov/cgi-bin/MODIS/soapservice/MODIS_soapservice.wsdl"
 
-
 @register_reader("modis_ornl")
 class MODISORNLReader(GriddedReader):
     """
@@ -94,7 +93,6 @@ class MODISORNLReader(GriddedReader):
 
         return ds
 
-
 def _nearest(items: pd.DatetimeIndex, pivot: pd.Timestamp) -> pd.Timestamp:
     """
     Find the nearest date in a list.
@@ -112,7 +110,6 @@ def _nearest(items: pd.DatetimeIndex, pivot: pd.Timestamp) -> pd.Timestamp:
         The nearest date.
     """
     return min(items, key=lambda x: abs(x - pivot))
-
 
 def _get_single_retrieval(
     date: pd.Timestamp,
@@ -197,7 +194,6 @@ def _get_single_retrieval(
 
     return ds
 
-
 def _make_xarray_dataset(grid_data: np.ndarray, metadata: dict) -> xr.Dataset:
     """
     Create an xarray Dataset from raw data and metadata.
@@ -242,7 +238,6 @@ def _make_xarray_dataset(grid_data: np.ndarray, metadata: dict) -> xr.Dataset:
     ds = update_history(ds, "Created xarray Dataset from MODIS ORNL subset.")
 
     return ds
-
 
 def _get_latlon(
     xll: float, yll: float, cell_width: float, nx: int, ny: int

--- a/monetio/readers/mopitt.py
+++ b/monetio/readers/mopitt.py
@@ -8,6 +8,7 @@ from .sat_utils import standardize_satellite_coords, tai93_to_datetime, update_h
 
 MOPITT_MISSING = -9999.0
 
+
 @register_reader("mopitt")
 class MOPITTReader(GriddedReader):
     """
@@ -79,6 +80,7 @@ class MOPITTReader(GriddedReader):
         ds = update_history(ds, "Read MOPITT L3 data.")
 
         return ds
+
 
 def mopitt_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """
@@ -172,6 +174,7 @@ def mopitt_preprocess(ds: xr.Dataset) -> xr.Dataset:
 
     return ds
 
+
 def _add_mopitt_pressure(ds: xr.Dataset) -> xr.Dataset:
     """
     Calculate 3D pressure array lazily for MOPITT.
@@ -224,6 +227,7 @@ def _add_mopitt_pressure(ds: xr.Dataset) -> xr.Dataset:
     ds_sorted["pressure"] = p_center.assign_attrs({"units": "hPa", "long_name": "Center Pressure"})
 
     return update_history(ds_sorted, "Calculated 3D center pressure lazily.")
+
 
 def _combine_mopitt_apriori(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/mopitt.py
+++ b/monetio/readers/mopitt.py
@@ -8,7 +8,6 @@ from .sat_utils import standardize_satellite_coords, tai93_to_datetime, update_h
 
 MOPITT_MISSING = -9999.0
 
-
 @register_reader("mopitt")
 class MOPITTReader(GriddedReader):
     """
@@ -67,7 +66,7 @@ class MOPITTReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -80,7 +79,6 @@ class MOPITTReader(GriddedReader):
         ds = update_history(ds, "Read MOPITT L3 data.")
 
         return ds
-
 
 def mopitt_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """
@@ -174,7 +172,6 @@ def mopitt_preprocess(ds: xr.Dataset) -> xr.Dataset:
 
     return ds
 
-
 def _add_mopitt_pressure(ds: xr.Dataset) -> xr.Dataset:
     """
     Calculate 3D pressure array lazily for MOPITT.
@@ -227,7 +224,6 @@ def _add_mopitt_pressure(ds: xr.Dataset) -> xr.Dataset:
     ds_sorted["pressure"] = p_center.assign_attrs({"units": "hPa", "long_name": "Center Pressure"})
 
     return update_history(ds_sorted, "Calculated 3D center pressure lazily.")
-
 
 def _combine_mopitt_apriori(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/mplnet.py
+++ b/monetio/readers/mplnet.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
-
 @register_reader("mplnet")
 class MPLNETReader(GriddedReader):
     """
@@ -64,7 +63,7 @@ class MPLNETReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -75,7 +74,6 @@ class MPLNETReader(GriddedReader):
         )
 
         return ds
-
 
 def mplnet_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/mplnet.py
+++ b/monetio/readers/mplnet.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
+
 @register_reader("mplnet")
 class MPLNETReader(GriddedReader):
     """
@@ -74,6 +75,7 @@ class MPLNETReader(GriddedReader):
         )
 
         return ds
+
 
 def mplnet_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/mrms.py
+++ b/monetio/readers/mrms.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("mrms")
 class MRMSReader(GriddedReader):
     """
@@ -80,6 +81,7 @@ class MRMSReader(GriddedReader):
         ds = update_history(ds, "Read MRMS data.")
 
         return ds
+
 
 def mrms_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/mrms.py
+++ b/monetio/readers/mrms.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("mrms")
 class MRMSReader(GriddedReader):
     """
@@ -68,7 +67,7 @@ class MRMSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -81,7 +80,6 @@ class MRMSReader(GriddedReader):
         ds = update_history(ds, "Read MRMS data.")
 
         return ds
-
 
 def mrms_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/nasa_modis.py
+++ b/monetio/readers/nasa_modis.py
@@ -6,7 +6,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("nasa_modis")
 class NASAMODISReader(GriddedReader):
     """
@@ -70,7 +69,7 @@ class NASAMODISReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -83,7 +82,6 @@ class NASAMODISReader(GriddedReader):
         ds = update_history(ds, "Read NASA MODIS data.")
 
         return ds
-
 
 def nasa_modis_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/nasa_modis.py
+++ b/monetio/readers/nasa_modis.py
@@ -6,6 +6,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("nasa_modis")
 class NASAMODISReader(GriddedReader):
     """
@@ -82,6 +83,7 @@ class NASAMODISReader(GriddedReader):
         ds = update_history(ds, "Read NASA MODIS data.")
 
         return ds
+
 
 def nasa_modis_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/ncep_grib.py
+++ b/monetio/readers/ncep_grib.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import update_history
 
+
 @register_reader("ncep_grib")
 class NCEPGribReader(GriddedReader):
     """
@@ -91,6 +92,7 @@ class NCEPGribReader(GriddedReader):
         ds = update_history(ds, "Read NCEP GRIB data.")
 
         return ds
+
 
 def ncep_grib_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/ncep_grib.py
+++ b/monetio/readers/ncep_grib.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import update_history
 
-
 @register_reader("ncep_grib")
 class NCEPGribReader(GriddedReader):
     """
@@ -68,7 +67,6 @@ class NCEPGribReader(GriddedReader):
         # Default to grib2io engine
         if "engine" not in kwargs:
             kwargs["engine"] = "grib2io"
-
         # Also supports open_mfdataset logic
         if "concat_dim" not in kwargs:
             kwargs["concat_dim"] = "time"
@@ -80,7 +78,7 @@ class NCEPGribReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="grib2",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -93,7 +91,6 @@ class NCEPGribReader(GriddedReader):
         ds = update_history(ds, "Read NCEP GRIB data.")
 
         return ds
-
 
 def ncep_grib_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/ncep_pds.py
+++ b/monetio/readers/ncep_pds.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader
 from .sat_utils import update_history
 
+
 class NCEPPDSReader(GriddedReader):
     """
     Base reader for NCEP products on AWS Public Dataset (PDS).

--- a/monetio/readers/ncep_pds.py
+++ b/monetio/readers/ncep_pds.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader
 from .sat_utils import update_history
 
-
 class NCEPPDSReader(GriddedReader):
     """
     Base reader for NCEP products on AWS Public Dataset (PDS).
@@ -76,7 +75,6 @@ class NCEPPDSReader(GriddedReader):
 
         if "engine" not in kwargs:
             kwargs["engine"] = "grib2io"
-
         # Note: Some kwargs passed to build_urls might not be valid for the driver,
         # but XarrayDriver.open generally handles this by consuming what it knows
         # and ignoring/forwarding the rest.
@@ -84,7 +82,7 @@ class NCEPPDSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="grib2",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,

--- a/monetio/readers/ncep_reanalysis.py
+++ b/monetio/readers/ncep_reanalysis.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("ncep_reanalysis")
 class NCEPReanalysisReader(GriddedReader):
     """
@@ -76,12 +75,11 @@ class NCEPReanalysisReader(GriddedReader):
 
         if "preprocess" not in kwargs:
             kwargs["preprocess"] = ncep_reanalysis_preprocess
-
         ds = super().open_dataset(
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="netcdf3",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -136,7 +134,6 @@ class NCEPReanalysisReader(GriddedReader):
             urls.append(url)
 
         return urls
-
 
 def ncep_reanalysis_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/ncep_reanalysis.py
+++ b/monetio/readers/ncep_reanalysis.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("ncep_reanalysis")
 class NCEPReanalysisReader(GriddedReader):
     """
@@ -134,6 +135,7 @@ class NCEPReanalysisReader(GriddedReader):
             urls.append(url)
 
         return urls
+
 
 def ncep_reanalysis_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/nesdis_edr_viirs.py
+++ b/monetio/readers/nesdis_edr_viirs.py
@@ -11,6 +11,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
+
 @register_reader("nesdis_edr_viirs")
 class NESDISEDRVIIRSReader(GriddedReader):
     """
@@ -152,6 +153,7 @@ class NESDISEDRVIIRSReader(GriddedReader):
             urls.append(url)
         return urls
 
+
 def read_nesdis_edr_binary(fname: str, **kwargs) -> xr.Dataset:
     """
     Read NESDIS EDR VIIRS binary data into an xarray.Dataset.
@@ -221,6 +223,7 @@ def read_nesdis_edr_binary(fname: str, **kwargs) -> xr.Dataset:
         pass
 
     return ds
+
 
 def nesdis_edr_viirs_preprocess(ds: xr.Dataset, resolution: str = "high") -> xr.Dataset:
     """

--- a/monetio/readers/nesdis_edr_viirs.py
+++ b/monetio/readers/nesdis_edr_viirs.py
@@ -11,7 +11,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
-
 @register_reader("nesdis_edr_viirs")
 class NESDISEDRVIIRSReader(GriddedReader):
     """
@@ -92,7 +91,7 @@ class NESDISEDRVIIRSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -152,7 +151,6 @@ class NESDISEDRVIIRSReader(GriddedReader):
             url = f"ftp://{server}{base_dir}/{year}/{filename}"
             urls.append(url)
         return urls
-
 
 def read_nesdis_edr_binary(fname: str, **kwargs) -> xr.Dataset:
     """
@@ -223,7 +221,6 @@ def read_nesdis_edr_binary(fname: str, **kwargs) -> xr.Dataset:
         pass
 
     return ds
-
 
 def nesdis_edr_viirs_preprocess(ds: xr.Dataset, resolution: str = "high") -> xr.Dataset:
     """

--- a/monetio/readers/nesdis_eps_viirs.py
+++ b/monetio/readers/nesdis_eps_viirs.py
@@ -9,6 +9,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import add_time_coord, standardize_satellite_coords, update_history
 
+
 @register_reader("nesdis_eps_viirs")
 class NESDISEPSVIIRSReader(GriddedReader):
     """
@@ -124,6 +125,7 @@ class NESDISEPSVIIRSReader(GriddedReader):
             url = f"ftp://{server}{base_dir}/{year}/npp_eaot_ip_gridded_0.25_{yyyymmdd}.high.nc"
             urls.append(url)
         return urls
+
 
 def nesdis_eps_viirs_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/nesdis_eps_viirs.py
+++ b/monetio/readers/nesdis_eps_viirs.py
@@ -9,7 +9,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import add_time_coord, standardize_satellite_coords, update_history
 
-
 @register_reader("nesdis_eps_viirs")
 class NESDISEPSVIIRSReader(GriddedReader):
     """
@@ -79,7 +78,7 @@ class NESDISEPSVIIRSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -125,7 +124,6 @@ class NESDISEPSVIIRSReader(GriddedReader):
             url = f"ftp://{server}{base_dir}/{year}/npp_eaot_ip_gridded_0.25_{yyyymmdd}.high.nc"
             urls.append(url)
         return urls
-
 
 def nesdis_eps_viirs_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/nesdis_frp.py
+++ b/monetio/readers/nesdis_frp.py
@@ -13,7 +13,6 @@ from .sat_utils import update_history
 
 BASE_URL = "https://gsce-dtn.sdstate.edu/index.php/s/e8wPYPOL1bGXk5z/download?path=%2F"
 
-
 @register_reader("nesdis_frp")
 class NESDISFRPReader(GriddedReader):
     """
@@ -95,12 +94,11 @@ class NESDISFRPReader(GriddedReader):
             kwargs["concat_dim"] = "tile"
         if "combine" not in kwargs:
             kwargs["combine"] = "nested"
-
         ds = super().open_dataset(
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -148,7 +146,6 @@ class NESDISFRPReader(GriddedReader):
             urls.append(url)
 
         return urls
-
 
 def read_nesdis_frp_binary(fname: str, **kwargs) -> xr.Dataset:
     """
@@ -235,7 +232,6 @@ def read_nesdis_frp_binary(fname: str, **kwargs) -> xr.Dataset:
         ds = ds.assign_coords(time=date).expand_dims("time")
 
     return ds
-
 
 def nesdis_frp_preprocess(ds: xr.Dataset, ftype: str = "meanFRP") -> xr.Dataset:
     """

--- a/monetio/readers/nesdis_frp.py
+++ b/monetio/readers/nesdis_frp.py
@@ -13,6 +13,7 @@ from .sat_utils import update_history
 
 BASE_URL = "https://gsce-dtn.sdstate.edu/index.php/s/e8wPYPOL1bGXk5z/download?path=%2F"
 
+
 @register_reader("nesdis_frp")
 class NESDISFRPReader(GriddedReader):
     """
@@ -147,6 +148,7 @@ class NESDISFRPReader(GriddedReader):
 
         return urls
 
+
 def read_nesdis_frp_binary(fname: str, **kwargs) -> xr.Dataset:
     """
     Read a single NESDIS FRP tile from a binary file.
@@ -232,6 +234,7 @@ def read_nesdis_frp_binary(fname: str, **kwargs) -> xr.Dataset:
         ds = ds.assign_coords(time=date).expand_dims("time")
 
     return ds
+
 
 def nesdis_frp_preprocess(ds: xr.Dataset, ftype: str = "meanFRP") -> xr.Dataset:
     """

--- a/monetio/readers/nesdis_viirs_jrr.py
+++ b/monetio/readers/nesdis_viirs_jrr.py
@@ -43,6 +43,7 @@ JRR_SPECS = {
     },
 }
 
+
 @register_reader("nesdis_viirs_jrr")
 @register_reader("viirs_jrr")
 class VIIRSJRRReader(GriddedReader):
@@ -201,6 +202,7 @@ class VIIRSJRRReader(GriddedReader):
 
         return sorted(urls)
 
+
 def viirs_jrr_preprocess(
     ds: xr.Dataset, product: str = "AOD", qa_threshold: float | None = None
 ) -> xr.Dataset:
@@ -252,6 +254,7 @@ def viirs_jrr_preprocess(
     ds = update_history(ds, f"Preprocessed NESDIS VIIRS JRR {product} data.")
 
     return ds
+
 
 # Legacy Alias
 VIIRSJRRAODReader = VIIRSJRRReader

--- a/monetio/readers/nesdis_viirs_jrr.py
+++ b/monetio/readers/nesdis_viirs_jrr.py
@@ -43,7 +43,6 @@ JRR_SPECS = {
     },
 }
 
-
 @register_reader("nesdis_viirs_jrr")
 @register_reader("viirs_jrr")
 class VIIRSJRRReader(GriddedReader):
@@ -134,7 +133,7 @@ class VIIRSJRRReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -202,7 +201,6 @@ class VIIRSJRRReader(GriddedReader):
 
         return sorted(urls)
 
-
 def viirs_jrr_preprocess(
     ds: xr.Dataset, product: str = "AOD", qa_threshold: float | None = None
 ) -> xr.Dataset:
@@ -254,7 +252,6 @@ def viirs_jrr_preprocess(
     ds = update_history(ds, f"Preprocessed NESDIS VIIRS JRR {product} data.")
 
     return ds
-
 
 # Legacy Alias
 VIIRSJRRAODReader = VIIRSJRRReader

--- a/monetio/readers/omps.py
+++ b/monetio/readers/omps.py
@@ -10,6 +10,7 @@ from .sat_utils import (
     update_history,
 )
 
+
 @register_reader("omps")
 class OMPSReader(GriddedReader):
     """
@@ -90,6 +91,7 @@ class OMPSReader(GriddedReader):
 
         return ds
 
+
 def omps_preprocess(ds: xr.Dataset, product: str = "nmto3_l2") -> xr.Dataset:
     """
     Preprocess OMPS dataset lazily.
@@ -125,6 +127,7 @@ def omps_preprocess(ds: xr.Dataset, product: str = "nmto3_l2") -> xr.Dataset:
     ds = _scientific_hygiene(ds)
 
     return ds
+
 
 def _preprocess_nmto3_l2(ds: xr.Dataset) -> xr.Dataset:
     """
@@ -207,6 +210,7 @@ def _preprocess_nmto3_l2(ds: xr.Dataset) -> xr.Dataset:
     ds = update_history(ds, "Preprocessed OMPS L2 data.")
 
     return ds
+
 
 def _preprocess_nmto3_l3(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/omps.py
+++ b/monetio/readers/omps.py
@@ -10,7 +10,6 @@ from .sat_utils import (
     update_history,
 )
 
-
 @register_reader("omps")
 class OMPSReader(GriddedReader):
     """
@@ -77,7 +76,7 @@ class OMPSReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -90,7 +89,6 @@ class OMPSReader(GriddedReader):
         ds = update_history(ds, f"Read OMPS {product} data.")
 
         return ds
-
 
 def omps_preprocess(ds: xr.Dataset, product: str = "nmto3_l2") -> xr.Dataset:
     """
@@ -127,7 +125,6 @@ def omps_preprocess(ds: xr.Dataset, product: str = "nmto3_l2") -> xr.Dataset:
     ds = _scientific_hygiene(ds)
 
     return ds
-
 
 def _preprocess_nmto3_l2(ds: xr.Dataset) -> xr.Dataset:
     """
@@ -210,7 +207,6 @@ def _preprocess_nmto3_l2(ds: xr.Dataset) -> xr.Dataset:
     ds = update_history(ds, "Preprocessed OMPS L2 data.")
 
     return ds
-
 
 def _preprocess_nmto3_l3(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/omps_nadir.py
+++ b/monetio/readers/omps_nadir.py
@@ -13,7 +13,6 @@ from .sat_utils import (
     update_history,
 )
 
-
 @register_reader("omps_nadir")
 class OMPSNadirReader(GriddedReader):
     """
@@ -117,7 +116,6 @@ class OMPSNadirReader(GriddedReader):
             kwargs["concat_dim"] = "time"
         if "combine" not in kwargs:
             kwargs["combine"] = "nested"
-
         dsets = []
         for g in groups:
             g_kwargs = kwargs.copy()
@@ -143,7 +141,7 @@ class OMPSNadirReader(GriddedReader):
 
             try:
                 # Open without the preprocessor at this stage
-                ds_g = super().open_dataset(g_files, **g_kwargs)
+                ds_g = super().open_dataset(g_files, **g_kwargs, virtualizarr_parser="hdf5")
                 dsets.append(ds_g)
             except (OSError, RuntimeError, ValueError):
                 # Not all groups may be present in all files
@@ -245,7 +243,6 @@ class OMPSNadirReader(GriddedReader):
 
         return sorted(urls)
 
-
 def omps_nadir_preprocess(ds: xr.Dataset, product: str = "v8toz") -> xr.Dataset:
     """
     Preprocess OMPS Nadir dataset lazily.
@@ -296,7 +293,6 @@ def omps_nadir_preprocess(ds: xr.Dataset, product: str = "v8toz") -> xr.Dataset:
 
     return ds
 
-
 def _preprocess_v8toz(ds: xr.Dataset) -> xr.Dataset:
     """
     Preprocess NOAA V8TOZ Total Ozone EDR.
@@ -342,7 +338,6 @@ def _preprocess_v8toz(ds: xr.Dataset) -> xr.Dataset:
         ds["ozone_column"] = ds["ozone_column"].where(ds["quality_flag"] == 0)
 
     return ds
-
 
 def _preprocess_sdr(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/omps_nadir.py
+++ b/monetio/readers/omps_nadir.py
@@ -13,6 +13,7 @@ from .sat_utils import (
     update_history,
 )
 
+
 @register_reader("omps_nadir")
 class OMPSNadirReader(GriddedReader):
     """
@@ -243,6 +244,7 @@ class OMPSNadirReader(GriddedReader):
 
         return sorted(urls)
 
+
 def omps_nadir_preprocess(ds: xr.Dataset, product: str = "v8toz") -> xr.Dataset:
     """
     Preprocess OMPS Nadir dataset lazily.
@@ -293,6 +295,7 @@ def omps_nadir_preprocess(ds: xr.Dataset, product: str = "v8toz") -> xr.Dataset:
 
     return ds
 
+
 def _preprocess_v8toz(ds: xr.Dataset) -> xr.Dataset:
     """
     Preprocess NOAA V8TOZ Total Ozone EDR.
@@ -338,6 +341,7 @@ def _preprocess_v8toz(ds: xr.Dataset) -> xr.Dataset:
         ds["ozone_column"] = ds["ozone_column"].where(ds["quality_flag"] == 0)
 
     return ds
+
 
 def _preprocess_sdr(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/raqms.py
+++ b/monetio/readers/raqms.py
@@ -12,6 +12,7 @@ from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 from .time_utils import parse_wrf_times
 
+
 @register_reader("raqms")
 class RAQMSReader(GriddedReader):
     """
@@ -121,6 +122,7 @@ class RAQMSReader(GriddedReader):
 
         return ds
 
+
 def raqms_preprocess(
     ds: xr.Dataset,
     *,
@@ -205,6 +207,7 @@ def raqms_preprocess(
 
     return ds
 
+
 def _fix_grid(ds: xr.Dataset) -> xr.Dataset:
     """
     Fix grid and coordinates for RAQMS.
@@ -282,6 +285,7 @@ def _fix_grid(ds: xr.Dataset) -> xr.Dataset:
 
     return ds
 
+
 def _fix_time(ds: xr.Dataset) -> xr.Dataset:
     """
     Fix time coordinate for RAQMS.
@@ -327,6 +331,7 @@ def _fix_time(ds: xr.Dataset) -> xr.Dataset:
         # Update history
         ds = update_history(ds, "Optimized time parsing.")
     return ds
+
 
 def _fix_pres(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/raqms.py
+++ b/monetio/readers/raqms.py
@@ -12,7 +12,6 @@ from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 from .time_utils import parse_wrf_times
 
-
 @register_reader("raqms")
 class RAQMSReader(GriddedReader):
     """
@@ -115,13 +114,12 @@ class RAQMSReader(GriddedReader):
 
         # 2. Open the dataset using standard xarray (via XarrayDriver)
         # Use fpaths instead of files to ensure consistent set of files
-        ds = self.driver.open(fpaths, **kwargs)
+        ds = self.driver.open(fpaths, virtualizarr_parser="hdf5", **kwargs)
 
         # Update history
         ds = update_history(ds, "Read RAQMS data.")
 
         return ds
-
 
 def raqms_preprocess(
     ds: xr.Dataset,
@@ -207,7 +205,6 @@ def raqms_preprocess(
 
     return ds
 
-
 def _fix_grid(ds: xr.Dataset) -> xr.Dataset:
     """
     Fix grid and coordinates for RAQMS.
@@ -285,7 +282,6 @@ def _fix_grid(ds: xr.Dataset) -> xr.Dataset:
 
     return ds
 
-
 def _fix_time(ds: xr.Dataset) -> xr.Dataset:
     """
     Fix time coordinate for RAQMS.
@@ -331,7 +327,6 @@ def _fix_time(ds: xr.Dataset) -> xr.Dataset:
         # Update history
         ds = update_history(ds, "Optimized time parsing.")
     return ds
-
 
 def _fix_pres(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/sentinel4.py
+++ b/monetio/readers/sentinel4.py
@@ -11,7 +11,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import apply_qa_mask, standardize_satellite_coords, update_history
 
-
 @register_reader("sentinel4")
 class Sentinel4Reader(GriddedReader):
     """
@@ -95,7 +94,7 @@ class Sentinel4Reader(GriddedReader):
                     files,
                     use_virtualizarr=use_virtualizarr,
                     virtualizarr_file=virtualizarr_file,
-                    virtualizarr_parser=virtualizarr_parser,
+                    virtualizarr_parser="hdf5",
                     virtualizarr_backend=virtualizarr_backend,
                     icechunk_repo=icechunk_repo,
                     use_icechunk=use_icechunk,
@@ -113,7 +112,7 @@ class Sentinel4Reader(GriddedReader):
                     files,
                     use_virtualizarr=use_virtualizarr,
                     virtualizarr_file=virtualizarr_file,
-                    virtualizarr_parser=virtualizarr_parser,
+                    virtualizarr_parser="hdf5",
                     virtualizarr_backend=virtualizarr_backend,
                     icechunk_repo=icechunk_repo,
                     use_icechunk=use_icechunk,
@@ -135,7 +134,6 @@ class Sentinel4Reader(GriddedReader):
         ds = update_history(ds, "Read Sentinel-4 L2 data.")
 
         return ds
-
 
 def sentinel4_preprocess(ds: xr.Dataset, qa_threshold: float | None = None) -> xr.Dataset:
     """

--- a/monetio/readers/sentinel4.py
+++ b/monetio/readers/sentinel4.py
@@ -11,6 +11,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import apply_qa_mask, standardize_satellite_coords, update_history
 
+
 @register_reader("sentinel4")
 class Sentinel4Reader(GriddedReader):
     """
@@ -134,6 +135,7 @@ class Sentinel4Reader(GriddedReader):
         ds = update_history(ds, "Read Sentinel-4 L2 data.")
 
         return ds
+
 
 def sentinel4_preprocess(ds: xr.Dataset, qa_threshold: float | None = None) -> xr.Dataset:
     """

--- a/monetio/readers/smap.py
+++ b/monetio/readers/smap.py
@@ -8,7 +8,6 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("smap")
 class SMAPReader(GriddedReader):
     """
@@ -83,7 +82,7 @@ class SMAPReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -135,7 +134,6 @@ class SMAPReader(GriddedReader):
             pass
 
         return urls
-
 
 def smap_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/smap.py
+++ b/monetio/readers/smap.py
@@ -8,6 +8,7 @@ import xarray as xr
 from .base import GriddedReader, _scientific_hygiene, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("smap")
 class SMAPReader(GriddedReader):
     """
@@ -134,6 +135,7 @@ class SMAPReader(GriddedReader):
             pass
 
         return urls
+
 
 def smap_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/tempo.py
+++ b/monetio/readers/tempo.py
@@ -5,7 +5,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
-
 @register_reader("tempo")
 class TEMPOReader(GriddedReader):
     """
@@ -84,7 +83,6 @@ class TEMPOReader(GriddedReader):
 
         if "engine" not in kwargs:
             kwargs["engine"] = "h5netcdf"
-
         dsets = []
         for g in groups:
             g_kwargs = kwargs.copy()
@@ -95,7 +93,7 @@ class TEMPOReader(GriddedReader):
                     files,
                     use_virtualizarr=use_virtualizarr,
                     virtualizarr_file=virtualizarr_file,
-                    virtualizarr_parser=virtualizarr_parser,
+                    virtualizarr_parser="hdf5",
                     virtualizarr_backend=virtualizarr_backend,
                     icechunk_repo=icechunk_repo,
                     use_icechunk=use_icechunk,
@@ -124,7 +122,6 @@ class TEMPOReader(GriddedReader):
         ds = update_history(ds, "Read TEMPO L2 data.")
 
         return ds
-
 
 def tempo_preprocess(ds: xr.Dataset, variable_dict: dict | None = None) -> xr.Dataset:
     """
@@ -209,7 +206,6 @@ def tempo_preprocess(ds: xr.Dataset, variable_dict: dict | None = None) -> xr.Da
     ds = update_history(ds, "Preprocessed TEMPO data.")
 
     return ds
-
 
 def _add_pressure(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/tempo.py
+++ b/monetio/readers/tempo.py
@@ -5,6 +5,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import standardize_satellite_coords, update_history
 
+
 @register_reader("tempo")
 class TEMPOReader(GriddedReader):
     """
@@ -123,6 +124,7 @@ class TEMPOReader(GriddedReader):
 
         return ds
 
+
 def tempo_preprocess(ds: xr.Dataset, variable_dict: dict | None = None) -> xr.Dataset:
     """
     Preprocess TEMPO dataset: standardize coordinates, handle units,
@@ -206,6 +208,7 @@ def tempo_preprocess(ds: xr.Dataset, variable_dict: dict | None = None) -> xr.Da
     ds = update_history(ds, "Preprocessed TEMPO data.")
 
     return ds
+
 
 def _add_pressure(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/tolnet.py
+++ b/monetio/readers/tolnet.py
@@ -6,6 +6,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
+
 @register_reader("tolnet")
 class TOLNetReader(GriddedReader):
     """
@@ -116,6 +117,7 @@ class TOLNetReader(GriddedReader):
         """
         return super().harmonize(ds)
 
+
 def read_tolnet(fname: str, chunks=None, **kwargs) -> xr.Dataset:
     """
     Read a single TOLNet HDF5 file lazily.
@@ -178,6 +180,7 @@ def read_tolnet(fname: str, chunks=None, **kwargs) -> xr.Dataset:
     ds = tolnet_preprocess(ds_data)
 
     return ds
+
 
 def tolnet_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/tolnet.py
+++ b/monetio/readers/tolnet.py
@@ -6,7 +6,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import update_history
 
-
 @register_reader("tolnet")
 class TOLNetReader(GriddedReader):
     """
@@ -80,7 +79,7 @@ class TOLNetReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -116,7 +115,6 @@ class TOLNetReader(GriddedReader):
             Harmonized dataset.
         """
         return super().harmonize(ds)
-
 
 def read_tolnet(fname: str, chunks=None, **kwargs) -> xr.Dataset:
     """
@@ -180,7 +178,6 @@ def read_tolnet(fname: str, chunks=None, **kwargs) -> xr.Dataset:
     ds = tolnet_preprocess(ds_data)
 
     return ds
-
 
 def tolnet_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/tropomi.py
+++ b/monetio/readers/tropomi.py
@@ -12,7 +12,6 @@ from .sat_utils import (
     update_history,
 )
 
-
 @register_reader("tropomi")
 class TROPOMIReader(GriddedReader):
     """
@@ -103,7 +102,6 @@ class TROPOMIReader(GriddedReader):
 
         if "engine" not in kwargs:
             kwargs["engine"] = "h5netcdf"
-
         dsets = []
         for g in groups:
             # We copy kwargs to avoid modifying the original dict in the loop
@@ -115,7 +113,7 @@ class TROPOMIReader(GriddedReader):
                     files,
                     use_virtualizarr=use_virtualizarr,
                     virtualizarr_file=virtualizarr_file,
-                    virtualizarr_parser=virtualizarr_parser,
+                    virtualizarr_parser="hdf5",
                     virtualizarr_backend=virtualizarr_backend,
                     icechunk_repo=icechunk_repo,
                     use_icechunk=use_icechunk,
@@ -146,7 +144,6 @@ class TROPOMIReader(GriddedReader):
         ds = update_history(ds, "Read TROPOMI data.")
 
         return ds
-
 
 def tropomi_preprocess(
     ds: xr.Dataset, calculate_pressure: bool = True, qa_threshold: float | None = None
@@ -224,7 +221,6 @@ def tropomi_preprocess(
     )
 
     return ds
-
 
 def _add_pressure_levels(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/tropomi.py
+++ b/monetio/readers/tropomi.py
@@ -12,6 +12,7 @@ from .sat_utils import (
     update_history,
 )
 
+
 @register_reader("tropomi")
 class TROPOMIReader(GriddedReader):
     """
@@ -145,6 +146,7 @@ class TROPOMIReader(GriddedReader):
 
         return ds
 
+
 def tropomi_preprocess(
     ds: xr.Dataset, calculate_pressure: bool = True, qa_threshold: float | None = None
 ) -> xr.Dataset:
@@ -221,6 +223,7 @@ def tropomi_preprocess(
     )
 
     return ds
+
 
 def _add_pressure_levels(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/ufs.py
+++ b/monetio/readers/ufs.py
@@ -16,6 +16,7 @@ from .base import (
 from .sat_utils import update_history
 from .ufs_specs import DIAGNOSTICS
 
+
 @register_reader("ufs")
 class UFSReader(GriddedReader):
     """
@@ -218,6 +219,7 @@ class UFSReader(GriddedReader):
 
         return ds
 
+
 def _calc_pressure(ds: xr.Dataset) -> xr.DataArray:
     """
     Calculate mid-layer pressure from hybrid coordinates.
@@ -257,6 +259,7 @@ def _calc_pressure(ds: xr.Dataset) -> xr.DataArray:
 
     p_mid.attrs.update({"units": "Pa", "long_name": "Pressure at layer mid-points"})
     return p_mid
+
 
 def _calc_hgt(ds: xr.Dataset) -> xr.DataArray:
     """

--- a/monetio/readers/ufs.py
+++ b/monetio/readers/ufs.py
@@ -16,7 +16,6 @@ from .base import (
 from .sat_utils import update_history
 from .ufs_specs import DIAGNOSTICS
 
-
 @register_reader("ufs")
 class UFSReader(GriddedReader):
     """
@@ -90,13 +89,12 @@ class UFSReader(GriddedReader):
             kwargs["concat_dim"] = "time"
         if "combine" not in kwargs:
             kwargs["combine"] = "nested"
-
         # Open dataset
         ds = super().open_dataset(
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -107,7 +105,7 @@ class UFSReader(GriddedReader):
 
         # Merge PM25 file if present
         if fname_pm25 is not None:
-            ds_pm25 = self.driver.open(fname_pm25, **kwargs)
+            ds_pm25 = self.driver.open(fname_pm25, virtualizarr_parser="hdf5", **kwargs)
             ds_pm25 = ds_pm25.drop_vars(["lat", "lon", "pfull"], errors="ignore")
             ds_pm25.attrs = {}
             from monetio.util import _try_merge_exact
@@ -220,7 +218,6 @@ class UFSReader(GriddedReader):
 
         return ds
 
-
 def _calc_pressure(ds: xr.Dataset) -> xr.DataArray:
     """
     Calculate mid-layer pressure from hybrid coordinates.
@@ -260,7 +257,6 @@ def _calc_pressure(ds: xr.Dataset) -> xr.DataArray:
 
     p_mid.attrs.update({"units": "Pa", "long_name": "Pressure at layer mid-points"})
     return p_mid
-
 
 def _calc_hgt(ds: xr.Dataset) -> xr.DataArray:
     """

--- a/monetio/readers/umbc_aerosol.py
+++ b/monetio/readers/umbc_aerosol.py
@@ -9,6 +9,7 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import apply_lazy_conversion, update_history
 
+
 @register_reader("umbc_aerosol")
 class UMBCAerosolReader(GriddedReader):
     """
@@ -114,6 +115,7 @@ class UMBCAerosolReader(GriddedReader):
         ds = update_history(ds, "Read UMBC Aerosol data.")
 
         return ds
+
 
 def umbc_aerosol_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/umbc_aerosol.py
+++ b/monetio/readers/umbc_aerosol.py
@@ -9,7 +9,6 @@ import xarray as xr
 from .base import GriddedReader, register_reader
 from .sat_utils import apply_lazy_conversion, update_history
 
-
 @register_reader("umbc_aerosol")
 class UMBCAerosolReader(GriddedReader):
     """
@@ -72,7 +71,6 @@ class UMBCAerosolReader(GriddedReader):
 
         if "engine" not in kwargs:
             kwargs["engine"] = "h5netcdf"
-
         dsets = []
         all_attrs = {}
         for g in groups:
@@ -84,7 +82,7 @@ class UMBCAerosolReader(GriddedReader):
                     files,
                     use_virtualizarr=use_virtualizarr,
                     virtualizarr_file=virtualizarr_file,
-                    virtualizarr_parser=virtualizarr_parser,
+                    virtualizarr_parser="hdf5",
                     virtualizarr_backend=virtualizarr_backend,
                     icechunk_repo=icechunk_repo,
                     use_icechunk=use_icechunk,
@@ -116,7 +114,6 @@ class UMBCAerosolReader(GriddedReader):
         ds = update_history(ds, "Read UMBC Aerosol data.")
 
         return ds
-
 
 def umbc_aerosol_preprocess(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/wrfchem.py
+++ b/monetio/readers/wrfchem.py
@@ -18,7 +18,6 @@ from .sat_utils import update_history
 from .time_utils import parse_wrf_times
 from .wrfchem_specs import DIAGNOSTICS
 
-
 @register_reader("wrfchem")
 class WRFChemReader(GriddedReader):
     """
@@ -107,7 +106,7 @@ class WRFChemReader(GriddedReader):
             files,
             use_virtualizarr=use_virtualizarr,
             virtualizarr_file=virtualizarr_file,
-            virtualizarr_parser=virtualizarr_parser,
+            virtualizarr_parser="hdf5",
             virtualizarr_backend=virtualizarr_backend,
             icechunk_repo=icechunk_repo,
             use_icechunk=use_icechunk,
@@ -163,7 +162,6 @@ class WRFChemReader(GriddedReader):
         ds = update_history(ds, "Harmonized WRF-Chem dataset.")
 
         return ds
-
 
 def wrfchem_preprocess(
     ds: xr.Dataset,
@@ -266,7 +264,6 @@ def wrfchem_preprocess(
     )
 
     return ds
-
 
 def _parse_wrf_times(ds: xr.Dataset) -> xr.Dataset:
     """

--- a/monetio/readers/wrfchem.py
+++ b/monetio/readers/wrfchem.py
@@ -18,6 +18,7 @@ from .sat_utils import update_history
 from .time_utils import parse_wrf_times
 from .wrfchem_specs import DIAGNOSTICS
 
+
 @register_reader("wrfchem")
 class WRFChemReader(GriddedReader):
     """
@@ -163,6 +164,7 @@ class WRFChemReader(GriddedReader):
 
         return ds
 
+
 def wrfchem_preprocess(
     ds: xr.Dataset,
     *,
@@ -264,6 +266,7 @@ def wrfchem_preprocess(
     )
 
     return ds
+
 
 def _parse_wrf_times(ds: xr.Dataset) -> xr.Dataset:
     """


### PR DESCRIPTION
This change optimizes massive cloud streaming by updating the `XarrayDriver` to use parallel sweeps and empty `loadable_variables` in `open_virtual_mfdataset` calls. Additionally, it enforces explicit `virtualizarr_parser` declarations across all gridded data readers (e.g., UFS, CMAQ, GOES, TROPOMI, NCEP products) to improve reliability, self-documentation, and performance by bypassing fallback inference logic.

---
*PR created automatically by Jules for task [9691058780414567833](https://jules.google.com/task/9691058780414567833) started by @bbakernoaa*