### PR TITLE
Add Zarr/Icechunk support with UGRID/CF conventions and append capability to CLI

### DIFF
--- a/monetio/cli.py
+++ b/monetio/cli.py
@@ -22,10 +22,26 @@ def parse_dates(dates):
     return list(dates)
 
 
-def handle_save(obj, output, as_pandas):
+def handle_save(
+    obj,
+    output,
+    as_pandas,
+    zarr=False,
+    icechunk=False,
+    icechunk_url=None,
+    append=False,
+    append_dim="time",
+):
     """Handle saving the loaded data object."""
-    if output:
+    if output or icechunk:
+        is_zarr = zarr or (output and output.endswith(".zarr"))
+        is_icechunk = icechunk or icechunk_url is not None
+
         if as_pandas or isinstance(obj, pd.DataFrame | pd.Series):
+            if is_zarr or is_icechunk:
+                click.echo("Error: Cannot save Pandas/Tabular data as Zarr/Icechunk. Use NetCDF/CSV.")
+                return
+
             # Handle dask dataframe
             if hasattr(obj, "compute"):
                 obj = obj.compute()
@@ -37,10 +53,41 @@ def handle_save(obj, output, as_pandas):
             click.echo(f"Saved to {output} (CSV)")
         else:
             if isinstance(obj, pd.DataFrame):
-                click.echo("Error: Cannot save DataFrame as NetCDF. Use --as-pandas for CSV.")
+                click.echo("Error: Cannot save DataFrame as NetCDF/Zarr. Use --as-pandas for CSV.")
                 return
-            obj.to_netcdf(output)
-            click.echo(f"Saved to {output} (NetCDF)")
+
+            if is_icechunk:
+                url = icechunk_url or output
+                try:
+                    import icechunk
+
+                    repo = icechunk.Repository.open_or_create(url)
+                    session = repo.writable_session("main")
+                    if append:
+                        obj.to_zarr(
+                            session.store, mode="a", append_dim=append_dim, consolidated=False
+                        )
+                        msg = f"Appended to Icechunk repository at {url} (dim: {append_dim})"
+                    else:
+                        obj.to_zarr(session.store, mode="w", consolidated=False)
+                        msg = f"Saved to Icechunk repository at {url}"
+
+                    session.commit(msg)
+                    click.echo(msg)
+                except ImportError:
+                    click.echo("Error: Icechunk not installed. Install with 'pip install icechunk'.")
+                except Exception as e:
+                    click.echo(f"Error saving to Icechunk: {e}")
+            elif is_zarr:
+                if append:
+                    obj.to_zarr(output, mode="a", append_dim=append_dim, consolidated=True)
+                    click.echo(f"Appended to {output} (Zarr, dim: {append_dim})")
+                else:
+                    obj.to_zarr(output, mode="w", consolidated=True)
+                    click.echo(f"Saved to {output} (Zarr)")
+            else:
+                obj.to_netcdf(output)
+                click.echo(f"Saved to {output} (NetCDF)")
     else:
         # Just print a summary if no output file specified
         click.echo(obj)
@@ -64,6 +111,20 @@ def common_options(f):
     f = click.option("--n-procs", default=1, help="Number of processors for parallel loading.")(f)
     f = click.option("--lazy", is_flag=True, help="Use Dask for lazy loading.")(f)
     f = click.option("--as-pandas", is_flag=True, help="Process and save as CSV (Pandas).")(f)
+    f = click.option("--zarr", is_flag=True, help="Save output in Zarr format.")(f)
+    f = click.option(
+        "--icechunk", is_flag=True, help="Save output in Icechunk format (requires icechunk)."
+    )(f)
+    f = click.option("--icechunk-url", help="Icechunk repository URL/path.")(f)
+    f = click.option(
+        "--ugrid",
+        is_flag=True,
+        help="Apply UGRID/CF conventions (default for Zarr/Icechunk output).",
+    )(f)
+    f = click.option("--append", is_flag=True, help="Append to existing Zarr/Icechunk store.")(f)
+    f = click.option(
+        "--append-dim", default="time", help="Dimension to append along (default 'time')."
+    )(f)
     return f
 
 
@@ -77,7 +138,140 @@ def common_options(f):
     multiple=True,
     help="Additional keyword arguments in key=value format.",
 )
-def load(source, dates, output, n_procs, lazy, as_pandas, files, kwargs):
+def to_zarr(
+    source,
+    dates,
+    output,
+    n_procs,
+    lazy,
+    as_pandas,
+    zarr,
+    icechunk,
+    icechunk_url,
+    ugrid,
+    append,
+    append_dim,
+    files,
+    kwargs,
+):
+    """
+    Process data from any source and save as a UGRID/CF-compliant Zarr store.
+    Implicitly applies --ugrid and --zarr.
+    """
+    if not output:
+        click.echo("Error: --output is required for to-zarr.")
+        return
+
+    # Force UGRID and Zarr
+    ugrid = True
+    zarr = True
+
+    # Reuse load logic
+    ctx = click.get_current_context()
+    return ctx.invoke(
+        load,
+        source=source,
+        dates=dates,
+        output=output,
+        n_procs=n_procs,
+        lazy=lazy,
+        as_pandas=as_pandas,
+        zarr=zarr,
+        icechunk=icechunk,
+        icechunk_url=icechunk_url,
+        ugrid=ugrid,
+        append=append,
+        append_dim=append_dim,
+        files=files,
+        kwargs=kwargs,
+    )
+
+
+@cli.command()
+@click.argument("source")
+@common_options
+@click.option("--files", "-f", multiple=True, help="File path(s) or glob pattern(s).")
+@click.option(
+    "--kwargs",
+    "-k",
+    multiple=True,
+    help="Additional keyword arguments in key=value format.",
+)
+def to_icechunk(
+    source,
+    dates,
+    output,
+    n_procs,
+    lazy,
+    as_pandas,
+    zarr,
+    icechunk,
+    icechunk_url,
+    ugrid,
+    append,
+    append_dim,
+    files,
+    kwargs,
+):
+    """
+    Process data from any source and save as a UGRID/CF-compliant Icechunk repository.
+    Implicitly applies --ugrid and --icechunk.
+    """
+    if not output and not icechunk_url:
+        click.echo("Error: --output or --icechunk-url is required for to-icechunk.")
+        return
+
+    # Force UGRID and Icechunk
+    ugrid = True
+    icechunk = True
+
+    # Reuse load logic
+    ctx = click.get_current_context()
+    return ctx.invoke(
+        load,
+        source=source,
+        dates=dates,
+        output=output,
+        n_procs=n_procs,
+        lazy=lazy,
+        as_pandas=as_pandas,
+        zarr=zarr,
+        icechunk=icechunk,
+        icechunk_url=icechunk_url,
+        ugrid=ugrid,
+        append=append,
+        append_dim=append_dim,
+        files=files,
+        kwargs=kwargs,
+    )
+
+
+@cli.command()
+@click.argument("source")
+@common_options
+@click.option("--files", "-f", multiple=True, help="File path(s) or glob pattern(s).")
+@click.option(
+    "--kwargs",
+    "-k",
+    multiple=True,
+    help="Additional keyword arguments in key=value format.",
+)
+def load(
+    source,
+    dates,
+    output,
+    n_procs,
+    lazy,
+    as_pandas,
+    zarr,
+    icechunk,
+    icechunk_url,
+    ugrid,
+    append,
+    append_dim,
+    files,
+    kwargs,
+):
     """
     Generic command to load data from any registered source.
 
@@ -116,6 +310,12 @@ def load(source, dates, output, n_procs, lazy, as_pandas, files, kwargs):
     click.echo(f"Loading {source} data...")
 
     # Build arguments dynamically to avoid passing defaults that might conflict
+    # If ugrid, zarr, or icechunk is requested, we force as_xarray
+    is_zarr = zarr or (output and output.endswith(".zarr"))
+    is_icechunk = icechunk or icechunk_url is not None
+    if ugrid or is_zarr or is_icechunk:
+        as_pandas = False
+
     load_kwargs = {"as_xarray": not as_pandas}
     if d is not None:
         load_kwargs["dates"] = d
@@ -125,9 +325,20 @@ def load(source, dates, output, n_procs, lazy, as_pandas, files, kwargs):
         load_kwargs["n_procs"] = n_procs
     if lazy:
         load_kwargs["lazy"] = lazy
+    if ugrid or is_zarr or is_icechunk:
+        load_kwargs["expand2d"] = True
 
     obj = monetio.load(source, **load_kwargs, **extra_kwargs)
-    handle_save(obj, output, as_pandas)
+    handle_save(
+        obj,
+        output,
+        as_pandas,
+        zarr=zarr,
+        icechunk=icechunk,
+        icechunk_url=icechunk_url,
+        append=append,
+        append_dim=append_dim,
+    )
 
 
 @cli.command()
@@ -136,10 +347,32 @@ def load(source, dates, output, n_procs, lazy, as_pandas, files, kwargs):
 @click.option("--product", default="AOD15", help="AERONET product (e.g., 'AOD15', 'SDA20').")
 @click.option("--daily", is_flag=True, help="Load daily averages.")
 @click.option("--inv-type", help="Inversion type (e.g., 'ALM15').")
-def aeronet(dates, output, n_procs, lazy, as_pandas, siteid, product, daily, inv_type):
+def aeronet(
+    dates,
+    output,
+    n_procs,
+    lazy,
+    as_pandas,
+    zarr,
+    icechunk,
+    icechunk_url,
+    ugrid,
+    append,
+    append_dim,
+    siteid,
+    product,
+    daily,
+    inv_type,
+):
     """Retrieve and process AERONET data."""
     d = parse_dates(dates)
     click.echo(f"Loading AERONET data for {d if d is not None else 'default dates'}...")
+
+    is_zarr = zarr or (output and output.endswith(".zarr"))
+    is_icechunk = icechunk or icechunk_url is not None
+    if ugrid or is_zarr or is_icechunk:
+        as_pandas = False
+
     obj = monetio.load(
         "aeronet",
         dates=d,
@@ -150,8 +383,18 @@ def aeronet(dates, output, n_procs, lazy, as_pandas, siteid, product, daily, inv
         n_procs=n_procs,
         lazy=lazy,
         as_xarray=not as_pandas,
+        expand2d=ugrid or is_zarr or is_icechunk,
     )
-    handle_save(obj, output, as_pandas)
+    handle_save(
+        obj,
+        output,
+        as_pandas,
+        zarr=zarr,
+        icechunk=icechunk,
+        icechunk_url=icechunk_url,
+        append=append,
+        append_dim=append_dim,
+    )
 
 
 @cli.command()
@@ -162,10 +405,30 @@ def aeronet(dates, output, n_procs, lazy, as_pandas, siteid, product, daily, inv
     default=True,
     help="Whether to return data in wide format (pollutants as columns).",
 )
-def airnow(dates, output, n_procs, lazy, as_pandas, daily, wide_fmt):
+def airnow(
+    dates,
+    output,
+    n_procs,
+    lazy,
+    as_pandas,
+    zarr,
+    icechunk,
+    icechunk_url,
+    ugrid,
+    append,
+    append_dim,
+    daily,
+    wide_fmt,
+):
     """Retrieve and process AirNow data."""
     d = parse_dates(dates)
     click.echo(f"Loading AirNow data for {d if d is not None else 'default dates'}...")
+
+    is_zarr = zarr or (output and output.endswith(".zarr"))
+    is_icechunk = icechunk or icechunk_url is not None
+    if ugrid or is_zarr or is_icechunk:
+        as_pandas = False
+
     obj = monetio.load(
         "airnow",
         dates=d,
@@ -174,8 +437,18 @@ def airnow(dates, output, n_procs, lazy, as_pandas, daily, wide_fmt):
         n_procs=n_procs,
         lazy=lazy,
         as_xarray=not as_pandas,
+        expand2d=ugrid or is_zarr or is_icechunk,
     )
-    handle_save(obj, output, as_pandas)
+    handle_save(
+        obj,
+        output,
+        as_pandas,
+        zarr=zarr,
+        icechunk=icechunk,
+        icechunk_url=icechunk_url,
+        append=append,
+        append_dim=append_dim,
+    )
 
 
 @cli.command()
@@ -183,11 +456,32 @@ def airnow(dates, output, n_procs, lazy, as_pandas, daily, wide_fmt):
 @click.option("--param", "-p", multiple=True, help="AQS parameter(s) to retrieve.")
 @click.option("--daily", is_flag=True, help="Load daily data.")
 @click.option("--network", help="Filter by network name.")
-def aqs(dates, output, n_procs, lazy, as_pandas, param, daily, network):
+def aqs(
+    dates,
+    output,
+    n_procs,
+    lazy,
+    as_pandas,
+    zarr,
+    icechunk,
+    icechunk_url,
+    ugrid,
+    append,
+    append_dim,
+    param,
+    daily,
+    network,
+):
     """Retrieve and process EPA AQS data."""
     d = parse_dates(dates)
     p = list(param) if param else None
     click.echo(f"Loading AQS data for {d if d is not None else 'default dates'}...")
+
+    is_zarr = zarr or (output and output.endswith(".zarr"))
+    is_icechunk = icechunk or icechunk_url is not None
+    if ugrid or is_zarr or is_icechunk:
+        as_pandas = False
+
     obj = monetio.load(
         "aqs",
         dates=d,
@@ -197,8 +491,18 @@ def aqs(dates, output, n_procs, lazy, as_pandas, param, daily, network):
         n_procs=n_procs,
         lazy=lazy,
         as_xarray=not as_pandas,
+        expand2d=ugrid or is_zarr or is_icechunk,
     )
-    handle_save(obj, output, as_pandas)
+    handle_save(
+        obj,
+        output,
+        as_pandas,
+        zarr=zarr,
+        icechunk=icechunk,
+        icechunk_url=icechunk_url,
+        append=append,
+        append_dim=append_dim,
+    )
 
 
 @cli.command()
@@ -208,10 +512,29 @@ def aqs(dates, output, n_procs, lazy, as_pandas, param, daily, network):
     default=True,
     help="Whether to return data in wide format.",
 )
-def openaq(dates, output, n_procs, lazy, as_pandas, wide_fmt):
+def openaq(
+    dates,
+    output,
+    n_procs,
+    lazy,
+    as_pandas,
+    zarr,
+    icechunk,
+    icechunk_url,
+    ugrid,
+    append,
+    append_dim,
+    wide_fmt,
+):
     """Retrieve and process OpenAQ data."""
     d = parse_dates(dates)
     click.echo(f"Loading OpenAQ data for {d if d is not None else 'default dates'}...")
+
+    is_zarr = zarr or (output and output.endswith(".zarr"))
+    is_icechunk = icechunk or icechunk_url is not None
+    if ugrid or is_zarr or is_icechunk:
+        as_pandas = False
+
     obj = monetio.load(
         "openaq",
         dates=d,
@@ -219,8 +542,18 @@ def openaq(dates, output, n_procs, lazy, as_pandas, wide_fmt):
         n_procs=n_procs,
         lazy=lazy,
         as_xarray=not as_pandas,
+        expand2d=ugrid or is_zarr or is_icechunk,
     )
-    handle_save(obj, output, as_pandas)
+    handle_save(
+        obj,
+        output,
+        as_pandas,
+        zarr=zarr,
+        icechunk=icechunk,
+        icechunk_url=icechunk_url,
+        append=append,
+        append_dim=append_dim,
+    )
 
 
 @cli.command(name="virtualizarr")

--- a/monetio/cli.py
+++ b/monetio/cli.py
@@ -39,7 +39,9 @@ def handle_save(
 
         if as_pandas or isinstance(obj, pd.DataFrame | pd.Series):
             if is_zarr or is_icechunk:
-                click.echo("Error: Cannot save Pandas/Tabular data as Zarr/Icechunk. Use NetCDF/CSV.")
+                click.echo(
+                    "Error: Cannot save Pandas/Tabular data as Zarr/Icechunk. Use NetCDF/CSV."
+                )
                 return
 
             # Handle dask dataframe
@@ -75,7 +77,9 @@ def handle_save(
                     session.commit(msg)
                     click.echo(msg)
                 except ImportError:
-                    click.echo("Error: Icechunk not installed. Install with 'pip install icechunk'.")
+                    click.echo(
+                        "Error: Icechunk not installed. Install with 'pip install icechunk'."
+                    )
                 except Exception as e:
                     click.echo(f"Error saving to Icechunk: {e}")
             elif is_zarr:

--- a/monetio/readers/airnow.py
+++ b/monetio/readers/airnow.py
@@ -146,7 +146,9 @@ class AirNowReader(PointReader):
             df = df.compute(num_workers=n_procs)
 
         if as_xarray:
-            ds = self.to_xarray(df, expand2d=wide_fmt, **kwargs)
+            # Filter out expand2d from kwargs if present to avoid double-passing
+            to_xr_kwargs = {k: v for k, v in kwargs.items() if k != "expand2d"}
+            ds = self.to_xarray(df, expand2d=wide_fmt, **to_xr_kwargs)
 
             # Ensure history from _post_process and harmonize is there
             # even if lost in DataFrame stage (Dask doesn't support .attrs)

--- a/monetio/readers/aqs.py
+++ b/monetio/readers/aqs.py
@@ -528,7 +528,9 @@ class AQSReader(PointReader):
             df = add_monitor_metadata(df, daily=daily, network=network)
 
         if as_xarray:
-            ds = self.to_xarray(df, expand2d=wide_fmt, wide_fmt=wide_fmt, **kwargs)
+            # Filter out expand2d from kwargs if present to avoid double-passing
+            to_xr_kwargs = {k: v for k, v in kwargs.items() if k != "expand2d"}
+            ds = self.to_xarray(df, expand2d=wide_fmt, wide_fmt=wide_fmt, **to_xr_kwargs)
             ds = update_history(ds, "Read AQS data.")
             return ds
 

--- a/monetio/readers/base.py
+++ b/monetio/readers/base.py
@@ -169,6 +169,7 @@ class PointReader(BaseReader):
         lazy: bool = False,
         use_dask: bool = False,
         meta: pd.DataFrame | pd.Series | dict | tuple | None = None,
+        expand2d: bool = True,
         **kwargs,
     ) -> Union[pd.DataFrame, xr.Dataset, "dd.DataFrame"]:
         """
@@ -225,7 +226,7 @@ class PointReader(BaseReader):
         df = force_object_strings(df)
 
         if as_xarray:
-            return self.to_xarray(df, **kwargs)
+            return self.to_xarray(df, expand2d=expand2d, **kwargs)
 
         return df
 
@@ -254,7 +255,10 @@ class PointReader(BaseReader):
         return super().harmonize(df)
 
     def to_xarray(
-        self, df: Union[pd.DataFrame, "dd.DataFrame"], expand2d: bool = True, **kwargs
+        self,
+        df: Union[pd.DataFrame, "dd.DataFrame"],
+        expand2d: bool = True,
+        **kwargs,
     ) -> xr.Dataset:
         """
         Convert the DataFrame to an xarray Dataset in UGRID convention.

--- a/monetio/readers/ish.py
+++ b/monetio/readers/ish.py
@@ -520,7 +520,9 @@ class ISHReader(PointReader):
             from ..util import ds_to_2d
 
             # We first convert to 1D
-            ds = self.to_xarray(df, expand2d=False, **kwargs)
+            # Filter out expand2d from kwargs to avoid double-passing it
+            to_xr_kwargs = {k: v for k, v in kwargs.items() if k != "expand2d"}
+            ds = self.to_xarray(df, expand2d=False, **to_xr_kwargs)
 
             # Metadata variables to preserve
             meta_coords = [

--- a/monetio/readers/ish_lite.py
+++ b/monetio/readers/ish_lite.py
@@ -250,7 +250,9 @@ class ISHLiteReader(PointReader):
             from ..util import ds_to_2d
 
             # We first convert to 1D UGRID
-            ds = self.to_xarray(df, expand2d=False, **kwargs)
+            # Filter out expand2d from kwargs to avoid double-passing it
+            to_xr_kwargs = {k: v for k, v in kwargs.items() if k != "expand2d"}
+            ds = self.to_xarray(df, expand2d=False, **to_xr_kwargs)
 
             # Metadata variables to preserve
             meta_coords = [

--- a/monetio/readers/ndbc.py
+++ b/monetio/readers/ndbc.py
@@ -119,7 +119,9 @@ class NDBCReader(PointReader):
         if as_xarray:
             # NDBC is already "wide" (one row per time/station)
             # expand2d=True will use ds_to_2d which works fine.
-            ds = self.to_xarray(df, expand2d=wide_fmt, **kwargs)
+            # Filter out expand2d from kwargs if present to avoid double-passing
+            to_xr_kwargs = {k: v for k, v in kwargs.items() if k != "expand2d"}
+            ds = self.to_xarray(df, expand2d=wide_fmt, **to_xr_kwargs)
             ds = update_history(ds, "Read NDBC buoy data.")
             return ds
 

--- a/monetio/readers/openaq.py
+++ b/monetio/readers/openaq.py
@@ -156,7 +156,9 @@ class OpenAQReader(PointReader):
         if as_xarray:
             # Pop expand2d from kwargs if present to avoid multiple values error
             exp2d = kwargs.pop("expand2d", wide_fmt)
-            ds = self.to_xarray(df, expand2d=exp2d, **kwargs)
+            # Filter out expand2d from kwargs if still present (defensive)
+            to_xr_kwargs = {k: v for k, v in kwargs.items() if k != "expand2d"}
+            ds = self.to_xarray(df, expand2d=exp2d, **to_xr_kwargs)
 
             # Update history
             ds = update_history(ds, "Read OpenAQ data.")
@@ -292,7 +294,10 @@ class OpenAQReader(PointReader):
         return df
 
     def to_xarray(
-        self, df: Union[pd.DataFrame, "dd.DataFrame"], expand2d: bool = True, **kwargs: Any
+        self,
+        df: Union[pd.DataFrame, "dd.DataFrame"],
+        expand2d: bool = True,
+        **kwargs: Any,
     ) -> xr.Dataset:
         """
         Convert OpenAQ DataFrame to Xarray Dataset, ensuring consistent naming.

--- a/monetio/readers/openaq_aws.py
+++ b/monetio/readers/openaq_aws.py
@@ -164,7 +164,9 @@ class OpenAQAWSReader(PointReader):
 
         if as_xarray:
             # Defer wide_fmt expansion to to_xarray (via ds_to_2d) to keep it lazy.
-            ds = self.to_xarray(df, expand2d=wide_fmt, **kwargs)
+            # Filter out expand2d from kwargs if present to avoid double-passing
+            to_xr_kwargs = {k: v for k, v in kwargs.items() if k != "expand2d"}
+            ds = self.to_xarray(df, expand2d=wide_fmt, **to_xr_kwargs)
 
             # Update history
             ds = update_history(ds, "Read OpenAQ AWS archive data.")
@@ -241,7 +243,10 @@ class OpenAQAWSReader(PointReader):
         return super().harmonize(df)
 
     def to_xarray(
-        self, df: Union[pd.DataFrame, "dd.DataFrame"], expand2d: bool = True, **kwargs
+        self,
+        df: Union[pd.DataFrame, "dd.DataFrame"],
+        expand2d: bool = True,
+        **kwargs,
     ) -> xr.Dataset:
         """
         Convert to Xarray with consistent naming for OpenAQ variables.

--- a/monetio/readers/openaq_v2.py
+++ b/monetio/readers/openaq_v2.py
@@ -564,7 +564,10 @@ class OpenAQV2Reader(PointReader):
         return df
 
     def to_xarray(
-        self, df: Union[pd.DataFrame, "dd.DataFrame"], wide_fmt: bool = True, **kwargs: Any
+        self,
+        df: Union[pd.DataFrame, "dd.DataFrame"],
+        expand2d: bool = True,
+        **kwargs: Any,
     ) -> xr.Dataset:
         """
         Convert to xarray and rename variables for consistency.
@@ -583,6 +586,8 @@ class OpenAQV2Reader(PointReader):
         xr.Dataset
             The loaded dataset.
         """
+        # OpenAQ v2 uses wide_fmt as an alias for expand2d
+        wide_fmt = kwargs.get("wide_fmt", expand2d)
         ds = super().to_xarray(df, expand2d=wide_fmt, **kwargs)
 
         if wide_fmt:

--- a/tests/test_cli_zarr.py
+++ b/tests/test_cli_zarr.py
@@ -1,0 +1,130 @@
+import gzip
+from unittest.mock import patch
+import pandas as pd
+import xarray as xr
+import pytest
+from click.testing import CliRunner
+from monetio.cli import cli
+import os
+import shutil
+
+@pytest.fixture
+def mock_ish_history():
+    return pd.DataFrame(
+        {
+            "station_id": ["72224400358"],
+            "usaf": ["722244"],
+            "wban": ["00358"],
+            "latitude": [38.9],
+            "longitude": [-76.9],
+            "ctry": ["US"],
+            "state": ["MD"],
+            "station name": ["Site 1"],
+            "elev(m)": [20.0],
+            "begin": [pd.Timestamp("1970-01-01")],
+            "end": [pd.Timestamp("2025-01-01")],
+        }
+    )
+
+def test_cli_to_zarr_and_append(tmp_path, mock_ish_history):
+    # Setup mock data - Step 1
+    line1 = "2020 09 01 00  256  184 10185  220   40 0 0 0"
+    fn1 = tmp_path / "722244-00358-2020_1.gz"
+    with gzip.open(fn1, "wb") as f:
+        f.write((line1 + "\n").encode())
+
+    output_zarr = tmp_path / "test_output.zarr"
+
+    runner = CliRunner()
+
+    def side_effect(self, dates=None):
+        self.history = mock_ish_history
+
+    with patch("monetio.readers.ish.ISH.read_ish_history", autospec=True, side_effect=side_effect):
+        # 1. Initial save
+        result = runner.invoke(cli, ["to-zarr", "ish_lite", "-f", str(fn1), "-o", str(output_zarr)])
+        assert result.exit_code == 0
+        assert "Saved to" in result.output
+
+        # 2. Setup more data for append
+        line2 = "2020 09 01 01  260  190 10190  220   45 0 0 0"
+        fn2 = tmp_path / "722244-00358-2020_2.gz"
+        with gzip.open(fn2, "wb") as f:
+            f.write((line2 + "\n").encode())
+
+        # 3. Append
+        result = runner.invoke(cli, ["to-zarr", "ish_lite", "-f", str(fn2), "-o", str(output_zarr), "--append"])
+        assert result.exit_code == 0
+        assert "Appended to" in result.output
+
+    # Verify content
+    ds = xr.open_zarr(output_zarr)
+    assert ds.sizes["time"] == 2
+    assert "temp" in ds.data_vars
+    assert ds.attrs["Conventions"] == "CF-1.8 UGRID-1.0"
+
+def test_cli_to_icechunk_logic(tmp_path, mock_ish_history):
+    # Setup mock data
+    line1 = "2020 09 01 00  256  184 10185  220   40 0 0 0"
+    fn = tmp_path / "722244-00358-2020.gz"
+    with gzip.open(fn, "wb") as f:
+        f.write((line1 + "\n").encode())
+
+    icechunk_url = str(tmp_path / "test_repo")
+
+    runner = CliRunner()
+
+    def side_effect(self, dates=None):
+        self.history = mock_ish_history
+
+    # Mock icechunk if not installed
+    try:
+        import icechunk
+    except ImportError:
+        import sys
+        from unittest.mock import MagicMock
+        mock_icechunk = MagicMock()
+        sys.modules["icechunk"] = mock_icechunk
+
+    with patch("monetio.readers.ish.ISH.read_ish_history", autospec=True, side_effect=side_effect):
+        with patch("xarray.Dataset.to_zarr") as mock_to_zarr:
+             result = runner.invoke(cli, ["to-icechunk", "ish_lite", "-f", str(fn), "--icechunk-url", icechunk_url])
+
+    assert result.exit_code == 0
+    if "Error: Icechunk not installed" in result.output:
+        pytest.skip("Icechunk not installed, verified error message")
+
+    assert "Saved to Icechunk repository" in result.output
+    # Verify it called to_zarr (with the store)
+    assert mock_to_zarr.called
+
+def test_cli_to_icechunk_append_logic(tmp_path, mock_ish_history):
+    # Setup mock data
+    line1 = "2020 09 01 00  256  184 10185  220   40 0 0 0"
+    fn = tmp_path / "722244-00358-2020.gz"
+    with gzip.open(fn, "wb") as f:
+        f.write((line1 + "\n").encode())
+
+    icechunk_url = str(tmp_path / "test_repo")
+
+    runner = CliRunner()
+
+    def side_effect(self, dates=None):
+        self.history = mock_ish_history
+
+    # Mock icechunk
+    import sys
+    from unittest.mock import MagicMock
+    mock_icechunk = MagicMock()
+    sys.modules["icechunk"] = mock_icechunk
+
+    with patch("monetio.readers.ish.ISH.read_ish_history", autospec=True, side_effect=side_effect):
+        with patch("xarray.Dataset.to_zarr") as mock_to_zarr:
+             result = runner.invoke(cli, ["to-icechunk", "ish_lite", "-f", str(fn), "--icechunk-url", icechunk_url, "--append"])
+
+    assert result.exit_code == 0
+    assert "Appended to Icechunk repository" in result.output
+    # Verify it called to_zarr with mode='a'
+    args, kwargs = mock_to_zarr.call_args
+    assert kwargs["mode"] == "a"
+    assert kwargs["append_dim"] == "time"

--- a/tests/test_cli_zarr.py
+++ b/tests/test_cli_zarr.py
@@ -1,12 +1,13 @@
 import gzip
 from unittest.mock import patch
+
 import pandas as pd
-import xarray as xr
 import pytest
+import xarray as xr
 from click.testing import CliRunner
+
 from monetio.cli import cli
-import os
-import shutil
+
 
 @pytest.fixture
 def mock_ish_history():
@@ -26,7 +27,13 @@ def mock_ish_history():
         }
     )
 
+
 def test_cli_to_zarr_and_append(tmp_path, mock_ish_history):
+    import importlib.util
+
+    if importlib.util.find_spec("zarr") is None:
+        pytest.skip("zarr not installed")
+
     # Setup mock data - Step 1
     line1 = "2020 09 01 00  256  184 10185  220   40 0 0 0"
     fn1 = tmp_path / "722244-00358-2020_1.gz"
@@ -53,7 +60,9 @@ def test_cli_to_zarr_and_append(tmp_path, mock_ish_history):
             f.write((line2 + "\n").encode())
 
         # 3. Append
-        result = runner.invoke(cli, ["to-zarr", "ish_lite", "-f", str(fn2), "-o", str(output_zarr), "--append"])
+        result = runner.invoke(
+            cli, ["to-zarr", "ish_lite", "-f", str(fn2), "-o", str(output_zarr), "--append"]
+        )
         assert result.exit_code == 0
         assert "Appended to" in result.output
 
@@ -62,6 +71,7 @@ def test_cli_to_zarr_and_append(tmp_path, mock_ish_history):
     assert ds.sizes["time"] == 2
     assert "temp" in ds.data_vars
     assert ds.attrs["Conventions"] == "CF-1.8 UGRID-1.0"
+
 
 def test_cli_to_icechunk_logic(tmp_path, mock_ish_history):
     # Setup mock data
@@ -78,17 +88,20 @@ def test_cli_to_icechunk_logic(tmp_path, mock_ish_history):
         self.history = mock_ish_history
 
     # Mock icechunk if not installed
-    try:
-        import icechunk
-    except ImportError:
+    import importlib.util
+
+    if importlib.util.find_spec("icechunk") is None:
         import sys
         from unittest.mock import MagicMock
+
         mock_icechunk = MagicMock()
         sys.modules["icechunk"] = mock_icechunk
 
     with patch("monetio.readers.ish.ISH.read_ish_history", autospec=True, side_effect=side_effect):
         with patch("xarray.Dataset.to_zarr") as mock_to_zarr:
-             result = runner.invoke(cli, ["to-icechunk", "ish_lite", "-f", str(fn), "--icechunk-url", icechunk_url])
+            result = runner.invoke(
+                cli, ["to-icechunk", "ish_lite", "-f", str(fn), "--icechunk-url", icechunk_url]
+            )
 
     assert result.exit_code == 0
     if "Error: Icechunk not installed" in result.output:
@@ -97,6 +110,7 @@ def test_cli_to_icechunk_logic(tmp_path, mock_ish_history):
     assert "Saved to Icechunk repository" in result.output
     # Verify it called to_zarr (with the store)
     assert mock_to_zarr.called
+
 
 def test_cli_to_icechunk_append_logic(tmp_path, mock_ish_history):
     # Setup mock data
@@ -115,12 +129,24 @@ def test_cli_to_icechunk_append_logic(tmp_path, mock_ish_history):
     # Mock icechunk
     import sys
     from unittest.mock import MagicMock
+
     mock_icechunk = MagicMock()
     sys.modules["icechunk"] = mock_icechunk
 
     with patch("monetio.readers.ish.ISH.read_ish_history", autospec=True, side_effect=side_effect):
         with patch("xarray.Dataset.to_zarr") as mock_to_zarr:
-             result = runner.invoke(cli, ["to-icechunk", "ish_lite", "-f", str(fn), "--icechunk-url", icechunk_url, "--append"])
+            result = runner.invoke(
+                cli,
+                [
+                    "to-icechunk",
+                    "ish_lite",
+                    "-f",
+                    str(fn),
+                    "--icechunk-url",
+                    icechunk_url,
+                    "--append",
+                ],
+            )
 
     assert result.exit_code == 0
     assert "Appended to Icechunk repository" in result.output


### PR DESCRIPTION
I have enhanced the MONETIO CLI to support saving processed data as UGRID/CF-compliant Zarr stores or Icechunk repositories. 

Key improvements:
1. **New CLI Commands**: Added `to-zarr` and `to-icechunk` for streamlined processing and conversion.
2. **Unified Options**: Enhanced existing commands (`load`, `airnow`, `aqs`, etc.) with flags for Zarr/Icechunk output, UGRID compliance, and data appending (`--append`, `--append-dim`).
3. **Icechunk Integration**: Implemented support for Icechunk repositories, including session management and commits.
4. **Robust UGRID Support**: Ensured that requesting Zarr/Icechunk output automatically triggers UGRID-1.0/CF-1.8 expansion for point observations.
5. **Reader Refactoring**: Fixed `TypeError` conflicts in multiple point readers by standardizing how they handle the `expand2d` parameter when it originates from the CLI.
6. **Testing**: Verified the new functionality with a dedicated test suite (`tests/test_cli_zarr.py`) covering both initial saves and appends for both backends.

---
*PR created automatically by Jules for task [14316389468537809481](https://jules.google.com/task/14316389468537809481) started by @bbakernoaa*