### PR TITLE
Modernize MADIS and NESDIS FRP Readers

### DIFF
--- a/monetio/readers/madis.py
+++ b/monetio/readers/madis.py
@@ -134,28 +134,28 @@ class MADISReader(PointReader):
         # Fallback to DataFrame if explicitly requested
         if lazy:
             # Avoid triggering a compute with .to_dataframe()
-            import dask.dataframe as dd
+            # Note: newer xarray has to_dask_dataframe on Dataset
+            try:
+                df = ds.to_dask_dataframe()
+            except (AttributeError, Exception):
+                # Manual fallback for older xarray or complex datasets
+                import dask.array as da
+                import dask.dataframe as dd
 
-            # Identify variables and coordinates with 'node' dimension
-            node_vars = [v for v in ds.variables if ds[v].dims == ("node",)]
+                node_vars = [v for v in ds.variables if ds[v].dims == ("node",)]
 
-            if not node_vars:
-                return pd.DataFrame()
+                if not node_vars:
+                    return pd.DataFrame()
 
-            # Create dask dataframe
-            # We use dd.concat to join 1D dask arrays into a DataFrame
-            # All variables here are guaranteed to have dimension ('node',)
-            import dask.array as da
+                chunks = ds.chunks.get("node", (ds.sizes["node"],))[0]
+                df_parts = []
+                for v in node_vars:
+                    data = ds[v].data
+                    if not hasattr(data, "dask"):
+                        data = da.from_array(data, chunks=chunks)
+                    df_parts.append(dd.from_dask_array(data.flatten(), columns=[v]))
 
-            chunks = ds.chunks.get("node", (ds.sizes["node"],))[0]
-            df_parts = []
-            for v in node_vars:
-                data = ds[v].data
-                if not hasattr(data, "dask"):
-                    data = da.from_array(data, chunks=chunks)
-                df_parts.append(dd.from_dask_array(data.flatten(), columns=[v]))
-
-            df = dd.concat(df_parts, axis=1)
+                df = dd.concat(df_parts, axis=1)
         else:
             df = ds.to_dataframe().reset_index()
 

--- a/monetio/readers/madis.py
+++ b/monetio/readers/madis.py
@@ -1,8 +1,16 @@
 """MADIS (Meteorological Assimilation Data Ingest System) Reader"""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pandas as pd
 import xarray as xr
 
+if TYPE_CHECKING:
+    import dask.dataframe as dd
+
+from ..util import force_object_strings
 from .base import PointReader, register_reader
 from .sat_utils import update_history
 
@@ -23,11 +31,12 @@ class MADISReader(PointReader):
         icechunk_repo: str | None = None,
         use_icechunk: bool = False,
         icechunk_url: str | None = None,
+        lazy: bool = False,
         use_dask: bool = False,
         as_xarray: bool = True,
         expand2d: bool = True,
         **kwargs,
-    ) -> xr.Dataset | pd.DataFrame:
+    ) -> xr.Dataset | pd.DataFrame | dd.DataFrame:
         """
         Reads MADIS NetCDF files.
 
@@ -49,16 +58,25 @@ class MADISReader(PointReader):
             Whether to use Icechunk, by default False.
         icechunk_url : str or None, optional
             Path to the Icechunk repository, by default None.
-        use_dask : bool, optional
+        lazy : bool, optional
             Whether to use Dask for lazy loading, by default False.
+        use_dask : bool, optional
+            Alias for ``lazy``.
+        as_xarray : bool, optional
+            Whether to return an xarray Dataset, by default True.
+        expand2d : bool, optional
+            Whether to expand to 2D UGRID format, by default True.
         **kwargs : dict
-            Additional arguments passed to PandasDriver.open or to_xarray.
+            Additional arguments passed to ``xr.open_dataset`` or ``xr.open_mfdataset``.
 
         Returns
         -------
-        xr.Dataset or pd.DataFrame
+        xr.Dataset or pd.DataFrame or dask.dataframe.DataFrame
             UGRID xarray dataset by default, or DataFrame if ``as_xarray=False``.
         """
+        if use_dask:
+            lazy = True
+
         # MADIS files are NetCDF but contain point data.
         # We can use xarray to open them and then convert to the MONETIO point format.
         if isinstance(files, str):
@@ -66,31 +84,85 @@ class MADISReader(PointReader):
 
             files = sorted(glob.glob(files)) if "*" in files else [files]
 
-        datasets = []
-        for f in files:
-            ds = xr.open_dataset(f, **kwargs)
-            # MADIS files often have 'recNum' as the dimension
-            if "recNum" in ds.dims:
-                ds = ds.rename({"recNum": "node"})
-            datasets.append(ds)
-
-        if len(datasets) > 1:
-            # Consolidate
-            ds = xr.concat(datasets, dim="node")
+        if lazy:
+            # We must set chunks to an empty dict if not provided to ensure dask-backed
+            if "chunks" not in kwargs:
+                kwargs["chunks"] = {}
+            ds = xr.open_mfdataset(files, combine="nested", concat_dim="recNum", **kwargs)
         else:
-            ds = datasets[0]
+            datasets = []
+            for f in files:
+                ds_single = xr.open_dataset(f, **kwargs)
+                datasets.append(ds_single)
+
+            if len(datasets) > 1:
+                ds = xr.concat(datasets, dim="recNum")
+            else:
+                ds = datasets[0]
+
+        # MADIS files often have 'recNum' as the dimension
+        if "recNum" in ds.dims:
+            ds = ds.rename({"recNum": "node"})
+
+        # Ensure node coordinate is set for both eager and lazy
+        if "node" in ds.dims and "node" not in ds.coords:
+            if lazy:
+                import dask.array as da
+
+                # Match chunking if possible
+                chunks = ds.chunks.get("node", (ds.sizes["node"],))
+                ds.coords["node"] = (("node",), da.arange(ds.sizes["node"], chunks=chunks[0]))
+            else:
+                import numpy as np
+
+                ds.coords["node"] = (("node",), np.arange(ds.sizes["node"]))
 
         ds = self.harmonize(ds)
 
-        df = ds.to_dataframe().reset_index()
+        if as_xarray:
+            # If it's already an xarray, we might still want to apply to_xarray
+            # for UGRID expansion if expand2d=True.
+            # But we can also do it via ds_to_2d directly to avoid round-trip.
+            if expand2d:
+                from ..util import ds_to_2d
+
+                ds = ds_to_2d(ds, fixed_location=self.fixed_location)
+
+            ds = update_history(ds, "Read MADIS data into xarray format.")
+            return ds
+
+        # Fallback to DataFrame if explicitly requested
+        if lazy:
+            # Avoid triggering a compute with .to_dataframe()
+            import dask.dataframe as dd
+
+            # Identify variables and coordinates with 'node' dimension
+            node_vars = [v for v in ds.variables if ds[v].dims == ("node",)]
+
+            if not node_vars:
+                return pd.DataFrame()
+
+            # Create dask dataframe
+            # We use dd.concat to join 1D dask arrays into a DataFrame
+            # All variables here are guaranteed to have dimension ('node',)
+            import dask.array as da
+
+            chunks = ds.chunks.get("node", (ds.sizes["node"],))[0]
+            df_parts = []
+            for v in node_vars:
+                data = ds[v].data
+                if not hasattr(data, "dask"):
+                    data = da.from_array(data, chunks=chunks)
+                df_parts.append(dd.from_dask_array(data.flatten(), columns=[v]))
+
+            df = dd.concat(df_parts, axis=1)
+        else:
+            df = ds.to_dataframe().reset_index()
+
+        df = force_object_strings(df)
         df.attrs = dict(ds.attrs)
 
-        if not as_xarray:
-            return df
-
-        ds_out = self.to_xarray(df, expand2d=expand2d)
-        ds_out = update_history(ds_out, "Converted MADIS data to UGRID xarray format.")
-        return ds_out
+        return df
 
     def harmonize(self, ds: xr.Dataset) -> xr.Dataset:
         """
@@ -136,7 +208,9 @@ class MADISReader(PointReader):
         # Handle time if it's in seconds since epoch
         if "time" in ds.variables:
             if ds["time"].attrs.get("units") == "seconds since 1970-01-01 00:00:00.0 +0000":
-                ds["time"] = pd.to_datetime(ds["time"].values, unit="s")
+                # Convert to datetime64[ns] lazily using vectorized operations
+                # Epoch is 1970-01-01
+                ds["time"] = (ds["time"] * 1e9).astype("datetime64[ns]")
 
         # Set coordinates
         coords = ["time", "siteid", "latitude", "longitude", "elevation"]

--- a/monetio/readers/nesdis_frp.py
+++ b/monetio/readers/nesdis_frp.py
@@ -266,12 +266,12 @@ def nesdis_frp_preprocess(ds: xr.Dataset, ftype: str = "meanFRP") -> xr.Dataset:
     # ds.tile is usually a scalar coordinate if it's from a single file (tile)
     # but could be an array if concatenated.
     try:
-        tile = int(ds.tile.values) if not hasattr(ds.tile.data, "dask") else None
+        # We use .item() to get the scalar value if it's a coordinate.
+        # This is acceptable for metadata used for structural grid selection.
+        tile = int(ds.tile)
     except (TypeError, ValueError):
         tile = None
 
-    # If tile is dask-backed, we might need to be careful.
-    # But tile should be a coordinate, usually small and eager.
     if tile is not None:
         try:
             import fv3grid as fg

--- a/tests/test_icap_mme.py
+++ b/tests/test_icap_mme.py
@@ -4,8 +4,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from monetio.readers.icap_mme import ICAPMMEReader
-from monetio.readers.icap_mme import build_urls
+from monetio.readers.icap_mme import ICAPMMEReader, build_urls
 
 
 def create_mock_icap_ds(lazy=False):

--- a/tests/test_madis_modern.py
+++ b/tests/test_madis_modern.py
@@ -1,0 +1,72 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from monetio.readers.madis import MADISReader
+
+
+@pytest.fixture
+def mock_madis_file(tmp_path):
+    fn = tmp_path / "madis_test.nc"
+
+    n_rec = 10
+    ds = xr.Dataset(
+        {
+            "observationTime": (("recNum",), np.arange(n_rec, dtype="float64") * 3600),
+            "latitude": (("recNum",), np.linspace(30, 40, n_rec)),
+            "longitude": (("recNum",), np.linspace(-100, -90, n_rec)),
+            "stationId": (("recNum",), [f"S{i}" for i in range(n_rec)]),
+            "temperature": (("recNum",), np.random.rand(n_rec).astype("f4")),
+        },
+        attrs={"Conventions": "CF-1.6"},
+    )
+    ds.observationTime.attrs["units"] = "seconds since 1970-01-01 00:00:00.0 +0000"
+
+    ds.to_netcdf(fn)
+    return str(fn)
+
+
+def test_madis_reader_eager_lazy(mock_madis_file):
+    reader = MADISReader()
+
+    # Eager (NumPy)
+    ds_eager = reader.open_dataset(mock_madis_file, lazy=False, as_xarray=True, expand2d=False)
+    assert not hasattr(ds_eager.temperature.data, "dask")
+    assert ds_eager.time.dtype == "datetime64[ns]"
+
+    # Lazy (Dask)
+    ds_lazy = reader.open_dataset(mock_madis_file, lazy=True, as_xarray=True, expand2d=False)
+    assert hasattr(ds_lazy.temperature.data, "dask")
+    assert ds_lazy.time.dtype == "datetime64[ns]"
+
+    # Assert identical results (after computing lazy)
+    xr.testing.assert_allclose(ds_eager, ds_lazy.compute())
+
+    # Check 2D expansion
+    ds_2d = reader.open_dataset(mock_madis_file, lazy=True, as_xarray=True, expand2d=True)
+    assert "node" in ds_2d.dims
+    assert "time" in ds_2d.dims
+    assert hasattr(ds_2d.temperature.data, "dask")
+
+
+def test_madis_reader_dataframe(mock_madis_file):
+    reader = MADISReader()
+
+    # Eager DataFrame
+    df = reader.open_dataset(mock_madis_file, lazy=False, as_xarray=False)
+    assert isinstance(df, pd.DataFrame)
+    assert "temperature" in df.columns
+    assert "time" in df.columns
+    assert df.time.dtype == "datetime64[ns]"
+
+    # Lazy DataFrame (Dask)
+    ddf = reader.open_dataset(mock_madis_file, lazy=True, as_xarray=False)
+    import dask.dataframe as dd
+
+    assert isinstance(ddf, dd.DataFrame)
+    assert "temperature" in ddf.columns
+    assert ddf.time.dtype == "datetime64[ns]"
+
+    # Assert identical
+    pd.testing.assert_frame_equal(df.set_index("node"), ddf.compute().set_index("node"))


### PR DESCRIPTION
I have modernized the MADIS and NESDIS FRP readers to adhere to the Aero Protocol. 

Key improvements:
1. **MADIS Reader**:
   - Refactored `open_dataset` to stay in xarray-land when `as_xarray=True`, avoiding expensive Eager round-trips through Pandas.
   - Implemented a lazy path for `as_xarray=False` that returns a `dask.dataframe.DataFrame` using `dd.concat` of flattened dask arrays.
   - Replaced `.values` access in `harmonize` with vectorized xarray operations for epoch time conversion.
   - Integrated `force_object_strings` to prevent nullable string dtype mismatches between Eager and Lazy backends.
2. **NESDIS FRP Reader**:
   - Fixed a bug in `nesdis_frp_preprocess` where dask-backed tile coordinates were incorrectly handled, causing grid assignment to fail.
   - Standardized coordinate extraction to be safe for both backend types.
3. **Validation**:
   - Added `tests/test_madis_modern.py` verifying identical results for Eager and Lazy execution.
   - Verified that existing `tests/test_nesdis_frp.py` continues to pass with improved robustness.
   - Passed all `pre-commit` checks (ruff, black, etc.).

---
*PR created automatically by Jules for task [3372600223895142184](https://jules.google.com/task/3372600223895142184) started by @bbakernoaa*